### PR TITLE
Establish SSOT: Backlog + Decisions + PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,10 @@
+## Summary
+- _Provide a concise description of your changes._
+
+## Checklist
+- [ ] Updated `/docs/backlog.md` when planning or priorities changed
+- [ ] Updated `/docs/decisions.md` when decisions were made or modified
+- [ ] Added tests or documentation as needed
+
+## Testing
+- _Describe how you tested your changes._

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -1,0 +1,13 @@
+# Backlog
+
+This document serves as the project's single source of truth (SSOT) for planning.
+
+## SSOT Policy
+- The backlog lives in this file.
+- Changes to the backlog happen only via PRs that edit `/docs/backlog.md`.
+- Project boards and issues should link back to sections in this document as the SSOT.
+
+## Prioritized Backlog
+1. Record architecture and process decisions
+2. Build initial game prototype
+3. Configure continuous integration

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -1,0 +1,15 @@
+# Decisions
+
+Architectural Decision Records (ADRs) documenting project choices.
+
+## ADR-0001: Adopt a Single Source of Truth for planning
+- Status: Accepted
+- Context: Planning information scattered across tools leads to confusion.
+- Decision: `/docs/backlog.md` is the authoritative backlog.
+- Consequences: All planning updates require PRs modifying the backlog.
+
+## ADR-0002: Track decisions in version control
+- Status: Accepted
+- Context: Decisions should be reviewable and traceable.
+- Decision: Maintain this ADR log in `/docs/decisions.md`.
+- Consequences: Each significant decision adds a new ADR entry.


### PR DESCRIPTION
This PR establishes a single source of truth for planning and decisions.
- Adds /docs/backlog.md (prioritized backlog, SSOT policy)
- Adds /docs/decisions.md (ADR log; ADR-0001, ADR-0002)
- Adds .github/PULL_REQUEST_TEMPLATE.md (enforces updates to backlog/decisions)

Process:
- Changes to the backlog happen only via PRs that edit /docs/backlog.md.
- Project boards/Issues should link back to sections in /docs/backlog.md (SSOT).


------
https://chatgpt.com/codex/tasks/task_e_68c707ff2544832993a897c72040d27d