### PR TITLE
Journal: re-date entries to 2025-09-13 & 2025-09-14 and fill content

### DIFF
--- a/docs/journal/2025-09-13.md
+++ b/docs/journal/2025-09-13.md
@@ -1,0 +1,19 @@
+# 2025-09-13 — Env setup, Codex↔GitHub flow, first τ-Bench demo
+
+## What shipped
+- Set up personal **Codex** environment (separate from employer org) and linked to personal GitHub repo.
+- Resolved auth/permission issues (no anonymous write access), learned the **Push PR** flow.
+- Bootstrapped a small **τ-Bench Airline offline** demo + smoke tests.
+- Implemented a **stateful multi-turn (escalating) attack** and a simple **refund-threshold filter**.
+- Opened/merged initial PRs via Codex UI.
+
+## Why it matters
+- Verified the toolchain end-to-end: Codex can change code, run tests, and open PRs in my fork.
+- Established the feedback loop: attack → predicate → **ASR** reporting, with deterministic offline behavior.
+
+## Links (PRs, JSONLs)
+- _(Add links to your first PRs and any JSONL paths if saved)_
+
+## Next
+- Repo hygiene: `.gitignore`, `Makefile`, standard folders.
+- Config-driven runs with machine-readable results.

--- a/docs/journal/2025-09-14.md
+++ b/docs/journal/2025-09-14.md
@@ -1,13 +1,23 @@
-# 2025-09-14 — Engine v1/v1.1, DA-shaped shims, SSOT
+# 2025-09-14 — Engine v1/v1.1, DA-shaped shims, SSOT, journal tooling
 
 ## What shipped
-- 
+- **Repo hygiene & skeleton**: `.gitignore`, `Makefile`, `configs/airline_escalating_v1/run.yaml`, and tidy folders.
+- **Experiment engine v1**: config-driven runner writing **JSONL** (`header`, per-`trial`, `summary`), prints `ASR=X/Y` + `JSONL​=…`.
+- **Engine v1.1**: **DoomArena-shaped shims** (`EscalatingDialogueAttackAdapter`, `OutOfPolicyRefundFilter`) and runner refactor to load from YAML.
+- **SSOT established**: `/docs/backlog.md`, `/docs/decisions.md`, and a PR template.
+- **Code review fix**: Makefile improved (venv dependency, no `source`, guarded `run`).
+- **Journal tooling**: `scripts/new_journal_entry.py` + `make journal`; created entry & index.
 
 ## Why it matters
-- 
+- We now have a **reproducible experiment engine**: one command to run, structured results, and a stable CLI that can swap in real DoomArena/τ-Bench without changing configs.
+- The **SSOT** prevents planning drift; backlog/decisions are changed via PRs only.
+- Journal automation keeps daily progress captured in-repo.
 
 ## Links (PRs, JSONLs)
-- 
+- _(Add links to Engine v1, v1.1, SSOT, Makefile fix, Journal tooling PRs)_
+- JSONL: `results/airline_escalating_v1/...` (from today’s runs)
 
 ## Next
-- 
+- Wire **real DoomArena τ-Bench Airline** (replace shims), keep JSONL schema.
+- Add `analysis/aggregate.py` → `summary.csv` + README table.
+- Provider-agnostic model loader + budget guard (still default offline).

--- a/docs/journal/index.md
+++ b/docs/journal/index.md
@@ -1,3 +1,4 @@
 # Project Journal (index)
 
-- [2025-09-14](./2025-09-14.md) — Engine v1/v1.1, DA-shaped shims, SSOT
+- [2025-09-14](./2025-09-14.md) — Engine v1/v1.1, DA-shaped shims, SSOT, journal tooling
+- [2025-09-13](./2025-09-13.md) — Env setup, Codex↔GitHub flow, first τ-Bench demo


### PR DESCRIPTION
## Summary
- Re-dated initial journal entry to 2025-09-13 with details on environment setup and first τ-Bench demo.
- Added new 2025-09-14 entry covering engine v1/v1.1, DoomArena-shaped shims, SSOT documents, and journal tooling.
- Updated journal index to list latest work first.

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c7304754608329b9616c896f637d61