### PR TITLE
Results aggregator v1: CSV + README table

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: venv install test run scaffold
+.PHONY: venv install test run aggregate report scaffold
 
 VENV := .venv
 PY   := $(VENV)/bin/python
@@ -10,7 +10,7 @@ venv:
 	$(PY) -m pip install -U pip
 
 install: venv
-	$(PIP) install -U doomarena doomarena-taubench pytest pyyaml
+	$(PIP) install -U doomarena doomarena-taubench pytest pyyaml pandas
 	$(PY) scripts/ensure_tau_bench.py || (echo "tau_bench unavailable; continuing without real τ-Bench" && exit 0)
 
 test: install
@@ -23,8 +23,15 @@ run: install
 	fi
 	$(PY) scripts/taubench_airline_da.py --config $(CONFIG)
 
+aggregate:
+	$(PY) scripts/aggregate_results.py
+
+report: aggregate
+	$(PY) scripts/update_readme_results.py
+
 scaffold:
 	mkdir -p adapters attacks defenses filters configs/airline_escalating_v1 results analysis
+
 .PHONY: journal
 journal: install
 	$(PY) scripts/new_journal_entry.py

--- a/README.md
+++ b/README.md
@@ -19,3 +19,12 @@ This repo currently uses thin adapters to mirror DoomArena concepts:
 | `adapters.filters.OutOfPolicyRefundFilter` | Success predicate / policy filter |
 
 **Next step:** replace these adapters with the real DoomArena/τ-Bench classes and keep the same CLI + JSONL outputs so experiment configs remain unchanged.
+
+## Results
+<!-- RESULTS:BEGIN -->
+
+| run_id | ASR | trials | path |
+| --- | --- | --- | --- |
+| [airline_escalating_seed42](results/airline_escalating_v1/airline_escalating_seed42.jsonl) | 0.600 | 5 | SHIM |
+
+<!-- RESULTS:END -->

--- a/scripts/aggregate_results.py
+++ b/scripts/aggregate_results.py
@@ -1,0 +1,84 @@
+import json
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+import pandas as pd
+
+
+def generate_if_needed(base_dir: Path) -> None:
+    jsonl_files = list(base_dir.rglob("*.jsonl"))
+    if jsonl_files:
+        return
+    cmd = [
+        sys.executable,
+        "scripts/taubench_airline_da_real.py",
+        "--config",
+        "configs/airline_escalating_v1/run.yaml",
+    ]
+    subprocess.run(cmd, check=True)
+
+
+def parse_jsonl(path: Path):
+    trials = successes = 0
+    asr = None
+    path_hint = "SHIM"
+    with path.open("r", encoding="utf-8") as f:
+        for line in f:
+            data = json.loads(line)
+            event = data.get("event")
+            if event == "trial":
+                trials += 1
+                if data.get("success"):
+                    successes += 1
+            elif event == "summary":
+                if {"trials", "successes", "asr"}.issubset(data):
+                    trials = data["trials"]
+                    successes = data["successes"]
+                    asr = data["asr"]
+                path_hint = data.get("path", path_hint)
+    if asr is None and trials:
+        asr = successes / trials
+    return trials, successes, asr, path_hint
+
+
+def main():
+    base_dir = Path("results")
+    base_dir.mkdir(exist_ok=True)
+    generate_if_needed(base_dir)
+    rows = []
+    for path in base_dir.rglob("*.jsonl"):
+        trials, successes, asr, path_hint = parse_jsonl(path)
+        mtime_ts = path.stat().st_mtime
+        mtime = datetime.fromtimestamp(mtime_ts, tz=timezone.utc).isoformat()
+        rows.append(
+            {
+                "run_id": path.stem,
+                "jsonl": path.as_posix(),
+                "trials": trials,
+                "successes": successes,
+                "asr": asr,
+                "path": path_hint,
+                "mtime": mtime,
+                "_mtime_ts": mtime_ts,
+            }
+        )
+    if not rows:
+        return
+    df = pd.DataFrame(rows)
+    df.sort_values("_mtime_ts", ascending=False, inplace=True)
+    df.drop(columns=["_mtime_ts"], inplace=True)
+    csv_path = base_dir / "summary.csv"
+    df.to_csv(csv_path, index=False)
+    md_path = base_dir / "summary.md"
+    with md_path.open("w", encoding="utf-8") as f:
+        f.write("| run_id | ASR | trials | path |\n")
+        f.write("| --- | --- | --- | --- |\n")
+        for _, row in df.iterrows():
+            link = f"[{row['run_id']}]({row['jsonl']})"
+            asr = "" if row["asr"] is None else f"{row['asr']:.3f}"
+            f.write(f"| {link} | {asr} | {row['trials']} | {row['path']} |\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/update_readme_results.py
+++ b/scripts/update_readme_results.py
@@ -1,0 +1,23 @@
+from pathlib import Path
+import re
+
+
+def main():
+    summary = Path("results/summary.md").read_text(encoding="utf-8").strip()
+    readme_path = Path("README.md")
+    text = readme_path.read_text(encoding="utf-8")
+    begin = "<!-- RESULTS:BEGIN -->"
+    end = "<!-- RESULTS:END -->"
+    if begin in text and end in text:
+        pattern = re.compile(f"{begin}.*?{end}", re.DOTALL)
+        replacement = f"{begin}\n\n{summary}\n\n{end}"
+        new_text = pattern.sub(replacement, text)
+    else:
+        if text and not text.endswith("\n"):
+            text += "\n"
+        new_text = text + "\n## Results\n" + begin + "\n\n" + summary + "\n\n" + end + "\n"
+    readme_path.write_text(new_text, encoding="utf-8")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_aggregate.py
+++ b/tests/test_aggregate.py
@@ -1,0 +1,16 @@
+import subprocess
+from pathlib import Path
+import pandas as pd
+
+
+def test_aggregate_generates_summary():
+    subprocess.check_call(["make", "report"])
+    csv_path = Path("results/summary.csv")
+    assert csv_path.exists()
+    df = pd.read_csv(csv_path)
+    assert len(df) >= 1
+    for col in ["run_id", "jsonl", "trials", "successes", "asr", "path", "mtime"]:
+        assert col in df.columns
+    readme = Path("README.md").read_text(encoding="utf-8")
+    assert "<!-- RESULTS:BEGIN -->" in readme
+    assert "<!-- RESULTS:END -->" in readme


### PR DESCRIPTION
## Summary
- implement aggregation script to parse result jsonl files, produce `results/summary.csv` and a markdown summary
- add script to inject summary table into README between RESULTS markers
- add Makefile targets for aggregation and reporting with pandas dependency and a test covering the workflow

## Testing
- `make install`
- `make report`
- `.venv/bin/python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c833c476e88329b3663541577a1579