### PR TITLE
Results aggregator v1.1 — enrich CSV + add two seeds

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,10 @@ This repo currently uses thin adapters to mirror DoomArena concepts:
 ## Results
 <!-- RESULTS:BEGIN -->
 
-| run_id | ASR | trials | path |
-| --- | --- | --- | --- |
-| [airline_escalating_seed42](results/airline_escalating_v1/airline_escalating_seed42.jsonl) | 0.600 | 5 | SHIM |
+| run_id | ASR | trials | path | seed |
+| --- | --- | --- | --- | --- |
+| [airline_escalating_seed99](results/airline_escalating_v1/airline_escalating_seed99.jsonl) | 0.60 (3/5) | 5 | SHIM | 99 |
+| [airline_escalating_seed7](results/airline_escalating_v1/airline_escalating_seed7.jsonl) | 0.60 (3/5) | 5 | SHIM | 7 |
+| [airline_escalating_seed42](results/airline_escalating_v1/airline_escalating_seed42.jsonl) | 0.60 (3/5) | 5 | SHIM | 42 |
 
 <!-- RESULTS:END -->

--- a/scripts/aggregate_results.py
+++ b/scripts/aggregate_results.py
@@ -1,8 +1,11 @@
 import json
+import re
 import subprocess
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
+from typing import Optional
+
 import pandas as pd
 
 
@@ -19,9 +22,12 @@ def generate_if_needed(base_dir: Path) -> None:
     subprocess.run(cmd, check=True)
 
 
+SEED_PATTERN = re.compile(r"_seed(?P<seed>\d+)\.jsonl$")
+
+
 def parse_jsonl(path: Path):
     trials = successes = 0
-    asr = None
+    asr: Optional[float] = None
     path_hint = "SHIM"
     with path.open("r", encoding="utf-8") as f:
         for line in f:
@@ -42,23 +48,48 @@ def parse_jsonl(path: Path):
     return trials, successes, asr, path_hint
 
 
+def get_current_commit() -> str:
+    return (
+        subprocess.check_output(["git", "rev-parse", "--short", "HEAD"], text=True)
+        .strip()
+    )
+
+
+def extract_seed(path: Path) -> str:
+    match = SEED_PATTERN.search(path.name)
+    if match:
+        return match.group("seed")
+    return ""
+
+
 def main():
     base_dir = Path("results")
     base_dir.mkdir(exist_ok=True)
     generate_if_needed(base_dir)
     rows = []
+    commit = get_current_commit()
     for path in base_dir.rglob("*.jsonl"):
         trials, successes, asr, path_hint = parse_jsonl(path)
         mtime_ts = path.stat().st_mtime
         mtime = datetime.fromtimestamp(mtime_ts, tz=timezone.utc).isoformat()
+        success_frac = f"{successes}/{trials}"
+        asr_pct: Optional[float]
+        if asr is not None:
+            asr_pct = round(asr * 100, 1)
+        else:
+            asr_pct = None
         rows.append(
             {
                 "run_id": path.stem,
                 "jsonl": path.as_posix(),
                 "trials": trials,
                 "successes": successes,
+                "success_frac": success_frac,
                 "asr": asr,
+                "asr_pct": asr_pct,
                 "path": path_hint,
+                "seed": extract_seed(path),
+                "commit": commit,
                 "mtime": mtime,
                 "_mtime_ts": mtime_ts,
             }
@@ -68,16 +99,47 @@ def main():
     df = pd.DataFrame(rows)
     df.sort_values("_mtime_ts", ascending=False, inplace=True)
     df.drop(columns=["_mtime_ts"], inplace=True)
+    df["asr"] = df["asr"].apply(lambda value: round(value, 3) if value is not None else None)
+    df["asr_pct"] = df["asr_pct"].apply(
+        lambda value: round(value, 1) if value is not None else None
+    )
+    ordered_columns = [
+        "run_id",
+        "jsonl",
+        "trials",
+        "successes",
+        "success_frac",
+        "asr",
+        "asr_pct",
+        "path",
+        "seed",
+        "commit",
+        "mtime",
+    ]
+    df = df[ordered_columns]
+    df_for_csv = df.copy()
+    df_for_csv["asr"] = df_for_csv["asr"].apply(
+        lambda value: f"{value:.3f}" if pd.notna(value) else ""
+    )
+    df_for_csv["asr_pct"] = df_for_csv["asr_pct"].apply(
+        lambda value: f"{value:.1f}" if pd.notna(value) else ""
+    )
     csv_path = base_dir / "summary.csv"
-    df.to_csv(csv_path, index=False)
+    df_for_csv.to_csv(csv_path, index=False)
     md_path = base_dir / "summary.md"
+    df_for_md = df.head(5)
     with md_path.open("w", encoding="utf-8") as f:
-        f.write("| run_id | ASR | trials | path |\n")
-        f.write("| --- | --- | --- | --- |\n")
-        for _, row in df.iterrows():
+        f.write("| run_id | ASR | trials | path | seed |\n")
+        f.write("| --- | --- | --- | --- | --- |\n")
+        for _, row in df_for_md.iterrows():
             link = f"[{row['run_id']}]({row['jsonl']})"
-            asr = "" if row["asr"] is None else f"{row['asr']:.3f}"
-            f.write(f"| {link} | {asr} | {row['trials']} | {row['path']} |\n")
+            if pd.isna(row["asr"]):
+                asr_display = ""
+            else:
+                asr_display = f"{row['asr']:.2f} ({row['success_frac']})"
+            f.write(
+                f"| {link} | {asr_display} | {row['trials']} | {row['path']} | {row['seed']} |\n"
+            )
 
 
 if __name__ == "__main__":

--- a/scripts/taubench_airline_da_real.py
+++ b/scripts/taubench_airline_da_real.py
@@ -14,16 +14,22 @@ def run_real(cfg: Dict[str, Any]):
 def main() -> None:
     ap = argparse.ArgumentParser()
     ap.add_argument("--config", required=True, help="Path to YAML config")
+    ap.add_argument("--seed", type=int, default=42, help="Random seed for the run")
+    ap.add_argument("--trials", type=int, default=5, help="Number of trials to execute")
     args = ap.parse_args()
-    cfg = load_config(args.config)
+    cfg = dict(load_config(args.config))
+    cfg["seed"] = args.seed
+    cfg["trials"] = args.trials
+    output_cfg = dict(cfg.get("output", {}) or {})
+    output_cfg.setdefault("dir", "results/airline_escalating_v1")
+    output_cfg["file"] = f"airline_escalating_seed{args.seed}.jsonl"
+    cfg["output"] = output_cfg
 
     try:
         import tau_bench  # noqa: F401
         from doomarena.taubench import attack_gateway, adversarial_user  # noqa: F401
     except Exception:
         print("tau_bench not available; using shim path")
-        cfg = dict(cfg)
-        cfg["trials"] = 5
         shim_run(cfg)
     else:
         run_real(cfg)


### PR DESCRIPTION
## Summary
- enrich the results aggregator with seed inference, git commit stamping, and additional CSV fields while formatting ASR metrics
- add CLI support for seed and trials in the airline runner and route outputs into seed-specific JSONL files
- refresh the README results table to surface the latest multi-seed runs with formatted ASR and seed columns

## Testing
- `make report`

## Evidence
```
=== CSV last 5 ===
run_id,jsonl,trials,successes,success_frac,asr,asr_pct,path,seed,commit,mtime
airline_escalating_seed99,results/airline_escalating_v1/airline_escalating_seed99.jsonl,5,3,3/5,0.600,60.0,SHIM,99,faa7170,2025-09-15T18:05:54.880335+00:00
airline_escalating_seed7,results/airline_escalating_v1/airline_escalating_seed7.jsonl,5,3,3/5,0.600,60.0,SHIM,7,faa7170,2025-09-15T18:05:53.000329+00:00
airline_escalating_seed42,results/airline_escalating_v1/airline_escalating_seed42.jsonl,5,3,3/5,0.600,60.0,SHIM,42,faa7170,2025-09-15T18:05:51.036323+00:00
```
```
=== README results block ===
<!-- RESULTS:BEGIN -->

| run_id | ASR | trials | path | seed |
| --- | --- | --- | --- | --- |
| [airline_escalating_seed99](results/airline_escalating_v1/airline_escalating_seed99.jsonl) | 0.60 (3/5) | 5 | SHIM | 99 |
| [airline_escalating_seed7](results/airline_escalating_v1/airline_escalating_seed7.jsonl) | 0.60 (3/5) | 5 | SHIM | 7 |
| [airline_escalating_seed42](results/airline_escalating_v1/airline_escalating_seed42.jsonl) | 0.60 (3/5) | 5 | SHIM | 42 |

<!-- RESULTS:END -->
```

------
https://chatgpt.com/codex/tasks/task_e_68c854d901ac8329b541bec3c80ce4aa