### PR TITLE
Results engine v1.1: batch runs + metadata + README

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,10 @@ __pycache__/
 .venv/
 .env
 .ipynb_checkpoints/
-results/
+results/*
+!results/.gitkeep
+!results/summary.csv
+!results/summary.md
 artifacts/
 .cache/
 dist/

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,14 @@
-.PHONY: venv install test run aggregate report scaffold
+.PHONY: venv install test run sweep aggregate report scaffold
 
 VENV := .venv
 PY   := $(VENV)/bin/python
 PIP  := $(VENV)/bin/pip
 CONFIG ?= configs/airline_escalating_v1/run.yaml
+SEED ?= 42
+SEEDS ?= 41,42,43
+TRIALS ?= 5
+EXP ?= airline_escalating_v1
+MODE ?= SHIM
 
 venv:
 	python -m venv $(VENV)
@@ -16,12 +21,12 @@ install: venv
 test: install
 	$(PY) -m pytest -q
 
-run: install
-	@if [ ! -f scripts/taubench_airline_da.py ]; then \
-	  echo "scripts/taubench_airline_da.py not found in this PR. Merge the engine-v2 PR (adds the runner) or create the script."; \
-	  exit 1; \
-	fi
-	$(PY) scripts/taubench_airline_da.py --config $(CONFIG)
+run:
+	. .venv/bin/activate && python scripts/run_batch.py --exp $(EXP) --seeds "$(SEED)" --trials $(TRIALS) --mode $(MODE)
+
+sweep:
+	. .venv/bin/activate && python scripts/run_batch.py --exp $(EXP) --seeds "$(SEEDS)" --trials $(TRIALS) --mode $(MODE)
+	$(MAKE) report
 
 aggregate:
 	$(PY) scripts/aggregate_results.py

--- a/README.md
+++ b/README.md
@@ -9,6 +9,15 @@ This repository is a scaffold for the TAUBench Airline example in DoomArena.
 - Tests: `make test`
 - Results (JSONL) will be written under `results/`.
 
+### Quickstart (experiments)
+
+```bash
+make sweep SEEDS="41,42,43" TRIALS=5 MODE=SHIM
+head -5 results/summary.csv
+```
+
+> MODE=REAL attempts τ-Bench (requires access).
+
 ### Swapping to real DoomArena classes
 
 This repo currently uses thin adapters to mirror DoomArena concepts:
@@ -23,10 +32,10 @@ This repo currently uses thin adapters to mirror DoomArena concepts:
 ## Results
 <!-- RESULTS:BEGIN -->
 
-| run_id | ASR | trials | path | seed |
-| --- | --- | --- | --- | --- |
-| [airline_escalating_seed99](results/airline_escalating_v1/airline_escalating_seed99.jsonl) | 0.60 (3/5) | 5 | SHIM | 99 |
-| [airline_escalating_seed7](results/airline_escalating_v1/airline_escalating_seed7.jsonl) | 0.60 (3/5) | 5 | SHIM | 7 |
-| [airline_escalating_seed42](results/airline_escalating_v1/airline_escalating_seed42.jsonl) | 0.60 (3/5) | 5 | SHIM | 42 |
+| exp | seed | mode | ASR | trials | successes | path |
+| --- | --- | --- | --- | --- | --- | --- |
+| airline_escalating_v1 | 43 | SHIM | 0.60 (3/5) | 5 | 3 | [airline_escalating_v1_seed43](results/airline_escalating_v1/airline_escalating_v1_seed43.jsonl) |
+| airline_escalating_v1 | 42 | SHIM | 0.60 (3/5) | 5 | 3 | [airline_escalating_v1_seed42](results/airline_escalating_v1/airline_escalating_v1_seed42.jsonl) |
+| airline_escalating_v1 | 41 | SHIM | 0.60 (3/5) | 5 | 3 | [airline_escalating_v1_seed41](results/airline_escalating_v1/airline_escalating_v1_seed41.jsonl) |
 
 <!-- RESULTS:END -->

--- a/results/summary.csv
+++ b/results/summary.csv
@@ -1,0 +1,4 @@
+timestamp,git_sha,exp,seed,mode,trials,successes,asr,py_version,path
+2025-09-15T18:51:51.431892+00:00,7b3d126,airline_escalating_v1,41,SHIM,5,3,0.600000,3.11.12,results/airline_escalating_v1/airline_escalating_v1_seed41.jsonl
+2025-09-15T18:51:51.434372+00:00,7b3d126,airline_escalating_v1,42,SHIM,5,3,0.600000,3.11.12,results/airline_escalating_v1/airline_escalating_v1_seed42.jsonl
+2025-09-15T18:51:51.436689+00:00,7b3d126,airline_escalating_v1,43,SHIM,5,3,0.600000,3.11.12,results/airline_escalating_v1/airline_escalating_v1_seed43.jsonl

--- a/results/summary.md
+++ b/results/summary.md
@@ -1,0 +1,5 @@
+| exp | seed | mode | ASR | trials | successes | path |
+| --- | --- | --- | --- | --- | --- | --- |
+| airline_escalating_v1 | 43 | SHIM | 0.60 (3/5) | 5 | 3 | [airline_escalating_v1_seed43](results/airline_escalating_v1/airline_escalating_v1_seed43.jsonl) |
+| airline_escalating_v1 | 42 | SHIM | 0.60 (3/5) | 5 | 3 | [airline_escalating_v1_seed42](results/airline_escalating_v1/airline_escalating_v1_seed42.jsonl) |
+| airline_escalating_v1 | 41 | SHIM | 0.60 (3/5) | 5 | 3 | [airline_escalating_v1_seed41](results/airline_escalating_v1/airline_escalating_v1_seed41.jsonl) |

--- a/scripts/aggregate_results.py
+++ b/scripts/aggregate_results.py
@@ -1,12 +1,27 @@
+import csv
 import json
+import platform
 import re
 import subprocess
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Optional
+from typing import Dict, List, Optional, Tuple
 
-import pandas as pd
+SUMMARY_COLUMNS = [
+    "timestamp",
+    "git_sha",
+    "exp",
+    "seed",
+    "mode",
+    "trials",
+    "successes",
+    "asr",
+    "py_version",
+    "path",
+]
+
+SEED_PATTERN = re.compile(r"_seed(?P<seed>\d+)\.jsonl$")
 
 
 def generate_if_needed(base_dir: Path) -> None:
@@ -22,30 +37,27 @@ def generate_if_needed(base_dir: Path) -> None:
     subprocess.run(cmd, check=True)
 
 
-SEED_PATTERN = re.compile(r"_seed(?P<seed>\d+)\.jsonl$")
-
-
-def parse_jsonl(path: Path):
-    trials = successes = 0
-    asr: Optional[float] = None
-    path_hint = "SHIM"
-    with path.open("r", encoding="utf-8") as f:
-        for line in f:
-            data = json.loads(line)
-            event = data.get("event")
-            if event == "trial":
-                trials += 1
-                if data.get("success"):
-                    successes += 1
-            elif event == "summary":
-                if {"trials", "successes", "asr"}.issubset(data):
-                    trials = data["trials"]
-                    successes = data["successes"]
-                    asr = data["asr"]
-                path_hint = data.get("path", path_hint)
-    if asr is None and trials:
-        asr = successes / trials
-    return trials, successes, asr, path_hint
+def parse_jsonl(path: Path) -> Tuple[int, int, float, Optional[str]]:
+    summary: Optional[Dict] = None
+    with path.open("r", encoding="utf-8") as handle:
+        for line in handle:
+            try:
+                data = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if data.get("event") == "summary":
+                summary = data
+    if summary is None:
+        raise RuntimeError(f"Missing summary in {path}")
+    trials = int(summary.get("trials", 0))
+    successes = int(summary.get("successes", 0))
+    if successes > trials:
+        successes = trials
+    asr = summary.get("asr")
+    if asr is None:
+        asr = successes / trials if trials else 0.0
+    mode = summary.get("mode")
+    return trials, successes, float(asr), mode
 
 
 def get_current_commit() -> str:
@@ -62,84 +74,132 @@ def extract_seed(path: Path) -> str:
     return ""
 
 
-def main():
+def normalize_mode(mode: Optional[str]) -> str:
+    if not mode:
+        return "SHIM"
+    value = str(mode).upper()
+    if value not in {"REAL", "SHIM"}:
+        return "SHIM"
+    return value
+
+
+def read_existing(summary_path: Path) -> Dict[Tuple[str, str], Dict[str, str]]:
+    rows: Dict[Tuple[str, str], Dict[str, str]] = {}
+    if not summary_path.exists():
+        return rows
+    with summary_path.open("r", encoding="utf-8", newline="") as handle:
+        reader = csv.DictReader(handle)
+        if reader.fieldnames is None:
+            return rows
+        if not set(SUMMARY_COLUMNS).issubset(set(reader.fieldnames)):
+            return rows
+        for row in reader:
+            exp = row.get("exp", "")
+            seed = row.get("seed", "")
+            if exp:
+                rows[(exp, seed)] = dict(row)
+    return rows
+
+
+def build_rows(base_dir: Path, existing: Dict[Tuple[str, str], Dict[str, str]]) -> List[Dict[str, str]]:
+    commit = get_current_commit()
+    py_version = platform.python_version()
+    now_iso = datetime.now(timezone.utc).isoformat()
+    rows: Dict[Tuple[str, str], Dict[str, str]] = dict(existing)
+    seen_keys: set[Tuple[str, str]] = set()
+
+    for path in sorted(base_dir.rglob("*.jsonl")):
+        exp = path.parent.name
+        seed = extract_seed(path)
+        key = (exp, seed)
+        trials, successes, asr, mode_hint = parse_jsonl(path)
+        row = dict(rows.get(key, {}))
+        timestamp = row.get("timestamp") or now_iso
+        mode = normalize_mode(mode_hint or row.get("mode"))
+        row.update(
+            {
+                "timestamp": timestamp,
+                "git_sha": commit,
+                "exp": exp,
+                "seed": seed,
+                "mode": mode,
+                "trials": str(trials),
+                "successes": str(successes),
+                "asr": f"{asr:.6f}",
+                "py_version": row.get("py_version") or py_version,
+                "path": path.as_posix(),
+            }
+        )
+        rows[key] = row
+        seen_keys.add(key)
+
+    normalized_rows: List[Dict[str, str]] = []
+    for (exp, seed), row in rows.items():
+        if seen_keys and (exp, seed) not in seen_keys:
+            continue
+        if not exp:
+            continue
+        normalized_rows.append({column: row.get(column, "") for column in SUMMARY_COLUMNS})
+
+    normalized_rows.sort(
+        key=lambda item: (
+            item.get("exp", ""),
+            int(item.get("seed", "0")) if item.get("seed", "").isdigit() else item.get("seed", ""),
+        )
+    )
+    return normalized_rows
+
+
+def write_summary(summary_path: Path, rows: List[Dict[str, str]]) -> None:
+    summary_path.parent.mkdir(parents=True, exist_ok=True)
+    with summary_path.open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=SUMMARY_COLUMNS)
+        writer.writeheader()
+        for row in rows:
+            writer.writerow(row)
+
+
+def write_summary_md(base_dir: Path, rows: List[Dict[str, str]]) -> None:
+    md_path = base_dir / "summary.md"
+    md_path.parent.mkdir(parents=True, exist_ok=True)
+    recent = sorted(rows, key=lambda item: item.get("timestamp", ""), reverse=True)[:5]
+    with md_path.open("w", encoding="utf-8") as handle:
+        handle.write("| exp | seed | mode | ASR | trials | successes | path |\n")
+        handle.write("| --- | --- | --- | --- | --- | --- | --- |\n")
+        for row in recent:
+            asr_display = ""
+            try:
+                asr_value = float(row.get("asr", ""))
+            except (TypeError, ValueError):
+                asr_value = None
+            if asr_value is not None:
+                asr_display = f"{asr_value:.2f} ({row.get('successes', '')}/{row.get('trials', '')})"
+            link = ""
+            if row.get("path"):
+                link = f"[{Path(row['path']).stem}]({row['path']})"
+            handle.write(
+                "| {exp} | {seed} | {mode} | {asr} | {trials} | {successes} | {link} |\n".format(
+                    exp=row.get("exp", ""),
+                    seed=row.get("seed", ""),
+                    mode=row.get("mode", ""),
+                    asr=asr_display,
+                    trials=row.get("trials", ""),
+                    successes=row.get("successes", ""),
+                    link=link,
+                )
+            )
+
+
+def main() -> None:
     base_dir = Path("results")
     base_dir.mkdir(exist_ok=True)
     generate_if_needed(base_dir)
-    rows = []
-    commit = get_current_commit()
-    for path in base_dir.rglob("*.jsonl"):
-        trials, successes, asr, path_hint = parse_jsonl(path)
-        mtime_ts = path.stat().st_mtime
-        mtime = datetime.fromtimestamp(mtime_ts, tz=timezone.utc).isoformat()
-        success_frac = f"{successes}/{trials}"
-        asr_pct: Optional[float]
-        if asr is not None:
-            asr_pct = round(asr * 100, 1)
-        else:
-            asr_pct = None
-        rows.append(
-            {
-                "run_id": path.stem,
-                "jsonl": path.as_posix(),
-                "trials": trials,
-                "successes": successes,
-                "success_frac": success_frac,
-                "asr": asr,
-                "asr_pct": asr_pct,
-                "path": path_hint,
-                "seed": extract_seed(path),
-                "commit": commit,
-                "mtime": mtime,
-                "_mtime_ts": mtime_ts,
-            }
-        )
-    if not rows:
-        return
-    df = pd.DataFrame(rows)
-    df.sort_values("_mtime_ts", ascending=False, inplace=True)
-    df.drop(columns=["_mtime_ts"], inplace=True)
-    df["asr"] = df["asr"].apply(lambda value: round(value, 3) if value is not None else None)
-    df["asr_pct"] = df["asr_pct"].apply(
-        lambda value: round(value, 1) if value is not None else None
-    )
-    ordered_columns = [
-        "run_id",
-        "jsonl",
-        "trials",
-        "successes",
-        "success_frac",
-        "asr",
-        "asr_pct",
-        "path",
-        "seed",
-        "commit",
-        "mtime",
-    ]
-    df = df[ordered_columns]
-    df_for_csv = df.copy()
-    df_for_csv["asr"] = df_for_csv["asr"].apply(
-        lambda value: f"{value:.3f}" if pd.notna(value) else ""
-    )
-    df_for_csv["asr_pct"] = df_for_csv["asr_pct"].apply(
-        lambda value: f"{value:.1f}" if pd.notna(value) else ""
-    )
-    csv_path = base_dir / "summary.csv"
-    df_for_csv.to_csv(csv_path, index=False)
-    md_path = base_dir / "summary.md"
-    df_for_md = df.head(5)
-    with md_path.open("w", encoding="utf-8") as f:
-        f.write("| run_id | ASR | trials | path | seed |\n")
-        f.write("| --- | --- | --- | --- | --- |\n")
-        for _, row in df_for_md.iterrows():
-            link = f"[{row['run_id']}]({row['jsonl']})"
-            if pd.isna(row["asr"]):
-                asr_display = ""
-            else:
-                asr_display = f"{row['asr']:.2f} ({row['success_frac']})"
-            f.write(
-                f"| {link} | {asr_display} | {row['trials']} | {row['path']} | {row['seed']} |\n"
-            )
+
+    summary_path = base_dir / "summary.csv"
+    existing_rows = read_existing(summary_path)
+    rows = build_rows(base_dir, existing_rows)
+    write_summary(summary_path, rows)
+    write_summary_md(base_dir, rows)
 
 
 if __name__ == "__main__":

--- a/scripts/run_batch.py
+++ b/scripts/run_batch.py
@@ -1,0 +1,248 @@
+import argparse
+import csv
+import json
+import platform
+import subprocess
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Dict, List, Tuple, Union
+
+from taubench_airline_da import load_config, run as shim_run
+
+try:
+    from taubench_airline_da_real import run_real as real_run
+except Exception:  # pragma: no cover - optional dependency
+    real_run = None
+
+
+SUMMARY_COLUMNS = [
+    "timestamp",
+    "git_sha",
+    "exp",
+    "seed",
+    "mode",
+    "trials",
+    "successes",
+    "asr",
+    "py_version",
+    "path",
+]
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Batch DoomArena runs")
+    parser.add_argument("--exp", default="airline_escalating_v1", help="Experiment name")
+    parser.add_argument(
+        "--seeds",
+        default="42",
+        help="Comma-separated list of seeds (e.g. \"41,42,43\")",
+    )
+    parser.add_argument("--trials", type=int, default=5, help="Trials per run")
+    parser.add_argument(
+        "--mode",
+        choices=("SHIM", "REAL"),
+        default="SHIM",
+        help="Execution mode",
+    )
+    parser.add_argument(
+        "--outdir",
+        default="results",
+        help="Base directory for experiment outputs",
+    )
+    return parser.parse_args()
+
+
+def parse_seed_list(raw: str) -> List[int]:
+    seeds: List[int] = []
+    for chunk in raw.split(","):
+        chunk = chunk.strip()
+        if not chunk:
+            continue
+        if not chunk.isdigit():
+            raise ValueError(f"Invalid seed value: {chunk}")
+        seeds.append(int(chunk))
+    if not seeds:
+        raise ValueError("At least one seed must be provided")
+    return seeds
+
+
+def git_sha() -> str:
+    return (
+        subprocess.check_output(["git", "rev-parse", "--short", "HEAD"], text=True)
+        .strip()
+    )
+
+
+def ensure_output_config(cfg: Dict, output_path: Path) -> Dict:
+    output_cfg = dict(cfg.get("output", {}) or {})
+    output_cfg["dir"] = output_path.parent.as_posix()
+    output_cfg["file"] = output_path.name
+    cfg["output"] = output_cfg
+    return cfg
+
+
+def load_summary_line(jsonl_path: Path) -> Dict:
+    summary: Dict | None = None
+    with jsonl_path.open("r", encoding="utf-8") as handle:
+        for line in handle:
+            try:
+                data = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if data.get("event") == "summary":
+                summary = data
+    if summary is None:
+        raise RuntimeError(f"Summary not found in {jsonl_path}")
+    return summary
+
+
+def parse_metrics(summary: Dict) -> Tuple[int, int, float]:
+    trials = int(summary.get("trials", 0))
+    successes = int(summary.get("successes", 0))
+    if trials < successes:
+        successes = trials
+    asr = summary.get("asr")
+    if asr is None:
+        asr = successes / trials if trials else 0.0
+    return trials, successes, float(asr)
+
+
+def read_existing_summary(summary_path: Path) -> List[Dict[str, str]]:
+    if not summary_path.exists():
+        return []
+    with summary_path.open("r", encoding="utf-8", newline="") as handle:
+        reader = csv.DictReader(handle)
+        if reader.fieldnames is None:
+            return []
+        if not set(SUMMARY_COLUMNS).issubset(set(reader.fieldnames)):
+            # Legacy schema; start fresh
+            return []
+        return [dict(row) for row in reader]
+
+
+def _seed_key(value: str) -> Union[int, str]:
+    if value and value.isdigit():
+        return int(value)
+    return value
+
+
+def upsert_summary_row(
+    rows: List[Dict[str, str]],
+    row: Dict[str, str],
+) -> List[Dict[str, str]]:
+    updated = False
+    for existing in rows:
+        if existing.get("exp") == row.get("exp") and existing.get("seed") == row.get("seed"):
+            existing.update(row)
+            updated = True
+            break
+    if not updated:
+        rows.append(row)
+    rows.sort(
+        key=lambda item: (item.get("exp", ""), _seed_key(item.get("seed", "")))
+    )
+    return rows
+
+
+def write_summary(summary_path: Path, rows: List[Dict[str, str]]) -> None:
+    summary_path.parent.mkdir(parents=True, exist_ok=True)
+    with summary_path.open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=SUMMARY_COLUMNS)
+        writer.writeheader()
+        for row in rows:
+            payload = {column: row.get(column, "") for column in SUMMARY_COLUMNS}
+            writer.writerow(payload)
+
+
+def run_single(
+    exp: str,
+    seed: int,
+    trials: int,
+    mode: str,
+    outdir: Path,
+    rows: List[Dict[str, str]],
+    commit: str,
+) -> None:
+    config_path = Path("configs") / exp / "run.yaml"
+    if not config_path.exists():
+        raise FileNotFoundError(f"Config not found: {config_path}")
+
+    cfg = load_config(str(config_path))
+    cfg["seed"] = seed
+    cfg["trials"] = trials
+    cfg["mode"] = mode
+
+    output_dir = outdir / exp
+    output_dir.mkdir(parents=True, exist_ok=True)
+    output_path = output_dir / f"{exp}_seed{seed}.jsonl"
+    ensure_output_config(cfg, output_path)
+
+    actual_mode = mode
+    if mode == "REAL":
+        try:  # pragma: no cover - requires external dependency
+            import tau_bench  # type: ignore
+        except Exception as exc:
+            print(f"tau_bench unavailable ({exc}); falling back to SHIM mode")
+            actual_mode = "SHIM"
+            shim_run(cfg)
+        else:
+            if real_run is None:
+                print("REAL mode requested but real runner unavailable; using SHIM")
+                actual_mode = "SHIM"
+                shim_run(cfg)
+            else:
+                real_run(cfg)
+    else:
+        shim_run(cfg)
+
+    summary = load_summary_line(output_path)
+    trials_count, successes, asr = parse_metrics(summary)
+
+    row = {
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "git_sha": commit,
+        "exp": exp,
+        "seed": str(seed),
+        "mode": actual_mode,
+        "trials": str(trials_count),
+        "successes": str(successes),
+        "asr": f"{asr:.6f}",
+        "py_version": platform.python_version(),
+        "path": output_path.as_posix(),
+    }
+
+    upsert_summary_row(rows, row)
+    print(
+        f"{exp} seed={seed} mode={actual_mode} -> {successes}/{trials_count}"
+        f" (ASR={asr:.3f})"
+    )
+
+
+def main() -> None:
+    args = parse_args()
+    try:
+        seeds = parse_seed_list(args.seeds)
+    except ValueError as exc:
+        raise SystemExit(str(exc)) from exc
+
+    outdir = Path(args.outdir)
+    summary_path = Path("results") / "summary.csv"
+    existing_rows = read_existing_summary(summary_path)
+    commit = git_sha()
+
+    for seed in seeds:
+        run_single(
+            exp=args.exp,
+            seed=seed,
+            trials=args.trials,
+            mode=args.mode,
+            outdir=outdir,
+            rows=existing_rows,
+            commit=commit,
+        )
+
+    write_summary(summary_path, existing_rows)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_aggregate.py
+++ b/tests/test_aggregate.py
@@ -1,16 +1,55 @@
 import subprocess
+import sys
 from pathlib import Path
+
 import pandas as pd
 
 
+EXPECTED_COLUMNS = [
+    "timestamp",
+    "git_sha",
+    "exp",
+    "seed",
+    "mode",
+    "trials",
+    "successes",
+    "asr",
+    "py_version",
+    "path",
+]
+
+
 def test_aggregate_generates_summary():
+    subprocess.check_call(
+        [
+            sys.executable,
+            "scripts/run_batch.py",
+            "--exp",
+            "airline_escalating_v1",
+            "--seeds",
+            "99",
+            "--trials",
+            "2",
+        ]
+    )
     subprocess.check_call(["make", "report"])
+
     csv_path = Path("results/summary.csv")
     assert csv_path.exists()
     df = pd.read_csv(csv_path)
     assert len(df) >= 1
-    for col in ["run_id", "jsonl", "trials", "successes", "asr", "path", "mtime"]:
-        assert col in df.columns
+    for column in EXPECTED_COLUMNS:
+        assert column in df.columns
+
+    asr_values = pd.to_numeric(df["asr"], errors="coerce")
+    trials = pd.to_numeric(df["trials"], errors="coerce")
+    successes = pd.to_numeric(df["successes"], errors="coerce")
+
+    assert asr_values.between(0.0, 1.0).all()
+    assert (trials >= successes).all()
+    assert (trials >= 0).all()
+    assert (successes >= 0).all()
+
     readme = Path("README.md").read_text(encoding="utf-8")
     assert "<!-- RESULTS:BEGIN -->" in readme
     assert "<!-- RESULTS:END -->" in readme

--- a/tests/test_summary_csv.py
+++ b/tests/test_summary_csv.py
@@ -1,0 +1,40 @@
+import csv
+from pathlib import Path
+
+EXPECTED_COLUMNS = [
+    "timestamp",
+    "git_sha",
+    "exp",
+    "seed",
+    "mode",
+    "trials",
+    "successes",
+    "asr",
+    "py_version",
+    "path",
+]
+
+
+def test_summary_csv_present_and_valid():
+    summary_path = Path("results/summary.csv")
+    assert summary_path.exists(), "results/summary.csv is missing"
+
+    with summary_path.open("r", encoding="utf-8", newline="") as handle:
+        reader = csv.DictReader(handle)
+        assert reader.fieldnames is not None, "summary.csv missing header"
+        for column in EXPECTED_COLUMNS:
+            assert column in reader.fieldnames, f"Missing column: {column}"
+
+        for row in reader:
+            assert row.get("trials"), "trials value missing"
+            assert row.get("successes"), "successes value missing"
+            assert row.get("asr"), "asr value missing"
+
+            trials = int(row["trials"])
+            successes = int(row["successes"])
+            asr = float(row["asr"])
+
+            assert trials >= 0, "trials must be non-negative"
+            assert successes >= 0, "successes must be non-negative"
+            assert trials >= successes, "successes cannot exceed trials"
+            assert 0.0 <= asr <= 1.0, "asr must be between 0 and 1"


### PR DESCRIPTION
## Summary
- add a batch runner script that iterates seeds/trials, records metadata, and appends to the shared summary CSV
- refresh the results aggregator, Makefile targets, and tests to consume the richer metadata
- document the sweep workflow and ship seeded sample outputs for the airline experiment

## Testing
- `. .venv/bin/activate && pytest -q`

## Sample output
```
timestamp,git_sha,exp,seed,mode,trials,successes,asr,py_version,path
2025-09-15T18:51:51.431892+00:00,7b3d126,airline_escalating_v1,41,SHIM,5,3,0.600000,3.11.12,results/airline_escalating_v1/airline_escalating_v1_seed41.jsonl
2025-09-15T18:51:51.434372+00:00,7b3d126,airline_escalating_v1,42,SHIM,5,3,0.600000,3.11.12,results/airline_escalating_v1/airline_escalating_v1_seed42.jsonl
2025-09-15T18:51:51.436689+00:00,7b3d126,airline_escalating_v1,43,SHIM,5,3,0.600000,3.11.12,results/airline_escalating_v1/airline_escalating_v1_seed43.jsonl
```


------
https://chatgpt.com/codex/tasks/task_e_68c85d55f30c8329ba1d6cd29cf996ed