### PR TITLE
Results engine v1.2: schema lock + run_id + repo_state

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: venv install test run sweep aggregate report scaffold
+.PHONY: venv install test run sweep aggregate report scaffold check-schema
 
 VENV := .venv
 PY   := $(VENV)/bin/python
@@ -20,6 +20,9 @@ install: venv
 
 test: install
 	$(PY) -m pytest -q
+
+check-schema: venv
+	$(PY) scripts/check_schema.py
 
 run:
 	. .venv/bin/activate && python scripts/run_batch.py --exp $(EXP) --seeds "$(SEED)" --trials $(TRIALS) --mode $(MODE)

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ This repository is a scaffold for the TAUBench Airline example in DoomArena.
 - Edit config at `configs/airline_escalating_v1/run.yaml`.
 - Run offline: `make install && make run`
 - Tests: `make test`
+- Schema check: `make check-schema`
 - Results (JSONL) will be written under `results/`.
 
 ### Quickstart (experiments)
@@ -34,8 +35,16 @@ This repo currently uses thin adapters to mirror DoomArena concepts:
 
 | exp | seed | mode | ASR | trials | successes | path |
 | --- | --- | --- | --- | --- | --- | --- |
-| airline_escalating_v1 | 43 | SHIM | 0.60 (3/5) | 5 | 3 | [airline_escalating_v1_seed43](results/airline_escalating_v1/airline_escalating_v1_seed43.jsonl) |
 | airline_escalating_v1 | 42 | SHIM | 0.60 (3/5) | 5 | 3 | [airline_escalating_v1_seed42](results/airline_escalating_v1/airline_escalating_v1_seed42.jsonl) |
-| airline_escalating_v1 | 41 | SHIM | 0.60 (3/5) | 5 | 3 | [airline_escalating_v1_seed41](results/airline_escalating_v1/airline_escalating_v1_seed41.jsonl) |
 
 <!-- RESULTS:END -->
+
+### Results schema
+
+`results/summary.csv` is locked to the following header (order matters):
+
+```
+timestamp,run_id,git_sha,repo_dirty,exp,seed,mode,trials,successes,asr,py_version,path
+```
+
+Use `make check-schema` to verify the file matches the expected schema.

--- a/results/summary.csv
+++ b/results/summary.csv
@@ -1,4 +1,2 @@
-timestamp,git_sha,exp,seed,mode,trials,successes,asr,py_version,path
-2025-09-15T18:51:51.431892+00:00,7b3d126,airline_escalating_v1,41,SHIM,5,3,0.600000,3.11.12,results/airline_escalating_v1/airline_escalating_v1_seed41.jsonl
-2025-09-15T18:51:51.434372+00:00,7b3d126,airline_escalating_v1,42,SHIM,5,3,0.600000,3.11.12,results/airline_escalating_v1/airline_escalating_v1_seed42.jsonl
-2025-09-15T18:51:51.436689+00:00,7b3d126,airline_escalating_v1,43,SHIM,5,3,0.600000,3.11.12,results/airline_escalating_v1/airline_escalating_v1_seed43.jsonl
+timestamp,run_id,git_sha,repo_dirty,exp,seed,mode,trials,successes,asr,py_version,path
+2025-09-15T19:21:49.438568+00:00,2025-09-15T19-21-49Z,895cb2e,true,airline_escalating_v1,42,SHIM,5,3,0.600000,3.11.12,results/airline_escalating_v1/airline_escalating_v1_seed42.jsonl

--- a/results/summary.md
+++ b/results/summary.md
@@ -1,5 +1,3 @@
 | exp | seed | mode | ASR | trials | successes | path |
 | --- | --- | --- | --- | --- | --- | --- |
-| airline_escalating_v1 | 43 | SHIM | 0.60 (3/5) | 5 | 3 | [airline_escalating_v1_seed43](results/airline_escalating_v1/airline_escalating_v1_seed43.jsonl) |
 | airline_escalating_v1 | 42 | SHIM | 0.60 (3/5) | 5 | 3 | [airline_escalating_v1_seed42](results/airline_escalating_v1/airline_escalating_v1_seed42.jsonl) |
-| airline_escalating_v1 | 41 | SHIM | 0.60 (3/5) | 5 | 3 | [airline_escalating_v1_seed41](results/airline_escalating_v1/airline_escalating_v1_seed41.jsonl) |

--- a/scripts/check_schema.py
+++ b/scripts/check_schema.py
@@ -1,0 +1,48 @@
+"""Validate the locked schema for results/summary.csv."""
+
+import csv
+import sys
+from pathlib import Path
+
+EXPECTED_HEADER = [
+    "timestamp",
+    "run_id",
+    "git_sha",
+    "repo_dirty",
+    "exp",
+    "seed",
+    "mode",
+    "trials",
+    "successes",
+    "asr",
+    "py_version",
+    "path",
+]
+
+
+def main() -> None:
+    summary_path = Path("results/summary.csv")
+    if not summary_path.exists():
+        print("results/summary.csv is missing", file=sys.stderr)
+        sys.exit(1)
+
+    with summary_path.open("r", encoding="utf-8", newline="") as handle:
+        reader = csv.reader(handle)
+        try:
+            header = next(reader)
+        except StopIteration:
+            print("results/summary.csv is empty", file=sys.stderr)
+            sys.exit(1)
+
+    if header != EXPECTED_HEADER:
+        print(
+            "summary.csv header mismatch:\n"
+            f"  expected: {EXPECTED_HEADER}\n"
+            f"  found:    {header}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_aggregate.py
+++ b/tests/test_aggregate.py
@@ -7,7 +7,9 @@ import pandas as pd
 
 EXPECTED_COLUMNS = [
     "timestamp",
+    "run_id",
     "git_sha",
+    "repo_dirty",
     "exp",
     "seed",
     "mode",
@@ -38,17 +40,20 @@ def test_aggregate_generates_summary():
     assert csv_path.exists()
     df = pd.read_csv(csv_path)
     assert len(df) >= 1
-    for column in EXPECTED_COLUMNS:
-        assert column in df.columns
+    assert list(df.columns) == EXPECTED_COLUMNS
 
     asr_values = pd.to_numeric(df["asr"], errors="coerce")
     trials = pd.to_numeric(df["trials"], errors="coerce")
     successes = pd.to_numeric(df["successes"], errors="coerce")
+    repo_dirty = df["repo_dirty"].astype(str).str.lower()
+    run_ids = df["run_id"].astype(str)
 
     assert asr_values.between(0.0, 1.0).all()
     assert (trials >= successes).all()
     assert (trials >= 0).all()
     assert (successes >= 0).all()
+    assert repo_dirty.isin(["true", "false"]).all()
+    assert run_ids.str.len().gt(0).all()
 
     readme = Path("README.md").read_text(encoding="utf-8")
     assert "<!-- RESULTS:BEGIN -->" in readme

--- a/tests/test_summary_csv.py
+++ b/tests/test_summary_csv.py
@@ -3,7 +3,9 @@ from pathlib import Path
 
 EXPECTED_COLUMNS = [
     "timestamp",
+    "run_id",
     "git_sha",
+    "repo_dirty",
     "exp",
     "seed",
     "mode",
@@ -22,13 +24,16 @@ def test_summary_csv_present_and_valid():
     with summary_path.open("r", encoding="utf-8", newline="") as handle:
         reader = csv.DictReader(handle)
         assert reader.fieldnames is not None, "summary.csv missing header"
-        for column in EXPECTED_COLUMNS:
-            assert column in reader.fieldnames, f"Missing column: {column}"
+        assert (
+            reader.fieldnames == EXPECTED_COLUMNS
+        ), f"Unexpected header order: {reader.fieldnames}"
 
         for row in reader:
             assert row.get("trials"), "trials value missing"
             assert row.get("successes"), "successes value missing"
             assert row.get("asr"), "asr value missing"
+            assert row.get("run_id"), "run_id value missing"
+            assert row.get("repo_dirty") in {"true", "false"}, "repo_dirty must be true/false"
 
             trials = int(row["trials"])
             successes = int(row["successes"])


### PR DESCRIPTION
## Summary
- lock `results/summary.csv` to the new schema with run metadata (`run_id`, `repo_dirty`) and ensure both the batch runner and aggregator emit the normalized columns in order.
- add `scripts/check_schema.py` plus a `make check-schema` target so the CSV header can be verified quickly.
- tighten the regression tests to assert the exact header, validate numeric ranges, and confirm run metadata is present while updating the README with the fixed schema documentation.

## Testing
- `make run SEED=42 TRIALS=5`
- `make check-schema`
- `make test`

## CSV preview (first 3 lines)
```
timestamp,run_id,git_sha,repo_dirty,exp,seed,mode,trials,successes,asr,py_version,path
2025-09-15T19:21:49.438568+00:00,2025-09-15T19-21-49Z,895cb2e,true,airline_escalating_v1,42,SHIM,5,3,0.600000,3.11.12,results/airline_escalating_v1/airline_escalating_v1_seed42.jsonl
```

------
https://chatgpt.com/codex/tasks/task_e_68c8651f82548329bdc6cf98e66bc241