### PR TITLE
UX polish: aliases + README quickstart

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: venv install test run sweep aggregate report scaffold check-schema plot
+.PHONY: venv install test run sweep aggregate report scaffold check-schema plot sweep3 real1
 
 VENV := .venv
 PY   := $(VENV)/bin/python
@@ -28,14 +28,17 @@ run:
 	. .venv/bin/activate && python scripts/run_batch.py --exp $(EXP) --seeds "$(SEED)" --trials $(TRIALS) --mode $(MODE)
 
 sweep:
-	. .venv/bin/activate && python scripts/run_batch.py --exp $(EXP) --seeds "$(SEEDS)" --trials $(TRIALS) --mode $(MODE)
-	$(MAKE) report
+        . .venv/bin/activate && python scripts/run_batch.py --exp $(EXP) --seeds "$(SEEDS)" --trials $(TRIALS) --mode $(MODE)
+        $(MAKE) report
+
+sweep3:
+        $(MAKE) sweep SEEDS="41,42,43" TRIALS=5 MODE=SHIM
 
 aggregate:
-	if [ -x "$(PY)" ]; then \
-		"$(PY)" scripts/aggregate_results.py; \
-	else \
-		python scripts/aggregate_results.py; \
+        if [ -x "$(PY)" ]; then \
+                "$(PY)" scripts/aggregate_results.py; \
+        else \
+                python scripts/aggregate_results.py; \
 	fi
 
 plot:
@@ -46,14 +49,17 @@ plot:
 	fi
 
 report: aggregate plot
-	if [ -x "$(PY)" ]; then \
-		"$(PY)" scripts/update_readme_results.py; \
-	else \
-		python scripts/update_readme_results.py; \
-	fi
+        if [ -x "$(PY)" ]; then \
+                "$(PY)" scripts/update_readme_results.py; \
+        else \
+                python scripts/update_readme_results.py; \
+        fi
+
+real1:
+        $(MAKE) run SEED=42 TRIALS=5 MODE=REAL
 
 scaffold:
-	mkdir -p adapters attacks defenses filters configs/airline_escalating_v1 results analysis
+        mkdir -p adapters attacks defenses filters configs/airline_escalating_v1 results analysis
 
 .PHONY: journal
 journal: install

--- a/README.md
+++ b/README.md
@@ -13,18 +13,13 @@ This repository is a scaffold for the TAUBench Airline example in DoomArena.
 ### Quickstart (experiments)
 
 ```bash
-make sweep SEEDS="41,42,43" TRIALS=5 MODE=SHIM
+# 3 seeds, 5 trials each (shim)
+make sweep3
 head -5 results/summary.csv
-```
-
-> MODE=REAL attempts τ-Bench (requires access).
-
-### Quick plots
-
-```bash
-make sweep SEEDS="41,42,43" TRIALS=5 MODE=SHIM
-open results/plots/asr_by_seed.png
-open results/plots/asr_over_time.png
+# plots
+make plot
+# try REAL (requires permissions), otherwise falls back:
+make real1
 ```
 
 ### Swapping to real DoomArena classes


### PR DESCRIPTION
## Summary
- add convenience `make sweep3` alias for the standard three-seed shim sweep
- add `make real1` alias that runs a single REAL-mode batch and still benefits from fallback
- refresh the README quickstart snippet to highlight the new aliases and plotting step

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c86d8239248329b83266287a341a3e