### PR TITLE
UX polish: aliases + README quickstart

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,17 +28,17 @@ run:
 	. .venv/bin/activate && python scripts/run_batch.py --exp $(EXP) --seeds "$(SEED)" --trials $(TRIALS) --mode $(MODE)
 
 sweep:
-        . .venv/bin/activate && python scripts/run_batch.py --exp $(EXP) --seeds "$(SEEDS)" --trials $(TRIALS) --mode $(MODE)
-        $(MAKE) report
+	. .venv/bin/activate && python scripts/run_batch.py --exp $(EXP) --seeds "$(SEEDS)" --trials $(TRIALS) --mode $(MODE)
+	$(MAKE) report
 
 sweep3:
-        $(MAKE) sweep SEEDS="41,42,43" TRIALS=5 MODE=SHIM
+	$(MAKE) sweep SEEDS="41,42,43" TRIALS=5 MODE=SHIM
 
 aggregate:
-        if [ -x "$(PY)" ]; then \
-                "$(PY)" scripts/aggregate_results.py; \
-        else \
-                python scripts/aggregate_results.py; \
+	if [ -x "$(PY)" ]; then \
+		"$(PY)" scripts/aggregate_results.py; \
+	else \
+		python scripts/aggregate_results.py; \
 	fi
 
 plot:
@@ -49,17 +49,17 @@ plot:
 	fi
 
 report: aggregate plot
-        if [ -x "$(PY)" ]; then \
-                "$(PY)" scripts/update_readme_results.py; \
-        else \
-                python scripts/update_readme_results.py; \
-        fi
+	if [ -x "$(PY)" ]; then \
+		"$(PY)" scripts/update_readme_results.py; \
+	else \
+		python scripts/update_readme_results.py; \
+	fi
 
 real1:
-        $(MAKE) run SEED=42 TRIALS=5 MODE=REAL
+	$(MAKE) run SEED=42 TRIALS=5 MODE=REAL
 
 scaffold:
-        mkdir -p adapters attacks defenses filters configs/airline_escalating_v1 results analysis
+	mkdir -p adapters attacks defenses filters configs/airline_escalating_v1 results analysis
 
 .PHONY: journal
 journal: install


### PR DESCRIPTION
## Summary
- add convenience `make sweep3` alias for the standard three-seed shim sweep
- add `make real1` alias that runs a single REAL-mode batch and still benefits from fallback
- refresh the README quickstart snippet to highlight the new aliases and plotting step
- restore tab indentation on the updated make recipes so the targets remain invocable

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c8701b252c8329a612e79590799ff5