### PR TITLE
Fix xsweep config loading for UTF-8

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,8 @@ sweep:
 xsweep:
 	. .venv/bin/activate && python - <<-'PY'
 	import subprocess, sys, yaml
-	cfg = yaml.safe_load(open("$(CONFIG)", "r"), encoding="utf-8") or {}
+        with open("$(CONFIG)", "r", encoding="utf-8") as cfg_file:
+            cfg = yaml.safe_load(cfg_file) or {}
 	seeds = cfg.get("seeds", [])
 	rc = 0
 	for s in seeds:


### PR DESCRIPTION
## Summary
- load the xsweep config file with UTF-8 encoding and pass the handle to `yaml.safe_load` to avoid the unsupported `encoding` kwarg

## Testing
- ```
  python - <<'PY'
  import yaml
  with open("configs/airline_escalating_v1/run.yaml", "r", encoding="utf-8") as cfg_file:
      cfg = yaml.safe_load(cfg_file) or {}
  print(type(cfg), list(cfg)[:3])
  PY
  ```

------
https://chatgpt.com/codex/tasks/task_e_68c87c8082b48329b0bf8e0d39f14d4c