### PR TITLE
Add xsweep script and CLI overrides

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,24 +36,8 @@ sweep:
 
 .ONESHELL: xsweep
 xsweep:
-.ONESHELL: xsweep
-xsweep:
-	. $(VENV)/bin/activate && python - <<'PY'
-import subprocess, sys, yaml
-with open("$(CONFIG)", "r", encoding="utf-8") as fh:
-    cfg = yaml.safe_load(fh) or {}
-seeds = cfg.get("seeds", [])
-rc = 0
-for s in seeds:
-    rc |= subprocess.call([
-        "bash","-lc",
-        ". .venv/bin/activate && python scripts/run_experiment.py --config $(CONFIG) --seed %d" % s,
-    ])
-sys.exit(rc)
-PY
+	. $(VENV)/bin/activate && python scripts/xsweep.py --config $(CONFIG) --mode $(MODE) --trials $(TRIALS)
 
-	sys.exit(rc)
-	PY
 
 sweep3:
 	$(MAKE) sweep SEEDS="41,42,43" TRIALS=5 MODE=SHIM

--- a/scripts/run_experiment.py
+++ b/scripts/run_experiment.py
@@ -33,6 +33,8 @@ def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Run a single experiment seed")
     parser.add_argument("--config", required=True, help="Path to experiment YAML config")
     parser.add_argument("--seed", type=int, help="Seed override", default=None)
+    parser.add_argument("--mode", help="Execution mode override", default=None)
+    parser.add_argument("--trials", type=int, help="Trials override", default=None)
     return parser.parse_args()
 
 
@@ -149,6 +151,11 @@ def run_shim(
 def main() -> None:
     args = parse_args()
     cfg = load_config(args.config)
+
+    if args.mode is not None:
+        cfg["mode"] = args.mode
+    if args.trials is not None:
+        cfg["trials"] = int(args.trials)
 
     exp = cfg.get("exp")
     if not exp:

--- a/scripts/xsweep.py
+++ b/scripts/xsweep.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import Iterable, List
+
+import yaml
+
+DEFAULT_MODE = "SHIM"
+DEFAULT_TRIALS = 5
+SCRIPT_DIR = Path(__file__).resolve().parent
+RUN_EXPERIMENT = SCRIPT_DIR / "run_experiment.py"
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run all seeds from an experiment config")
+    parser.add_argument("--config", required=True, help="Path to experiment YAML config")
+    parser.add_argument(
+        "--mode",
+        default=None,
+        help="Execution mode override to pass to run_experiment.py",
+    )
+    parser.add_argument(
+        "--trials",
+        type=int,
+        default=None,
+        help="Number of trials override to pass to run_experiment.py",
+    )
+    return parser.parse_args()
+
+
+def _resolve_mode(explicit_mode: str | None) -> str:
+    if explicit_mode:
+        return str(explicit_mode)
+    return os.environ.get("MODE", DEFAULT_MODE)
+
+
+def _resolve_trials(explicit_trials: int | None) -> int:
+    if explicit_trials is not None:
+        return int(explicit_trials)
+    env_value = os.environ.get("TRIALS")
+    if env_value is None:
+        return DEFAULT_TRIALS
+    try:
+        return int(env_value)
+    except ValueError as exc:
+        raise SystemExit(f"Invalid TRIALS value: {env_value!r}") from exc
+
+
+def _load_config(config_path: Path) -> dict:
+    with config_path.open("r", encoding="utf-8") as handle:
+        return yaml.safe_load(handle) or {}
+
+
+def _extract_seeds(raw_seeds: Iterable[int | str] | int | str | None) -> List[int]:
+    if raw_seeds is None:
+        return []
+    if isinstance(raw_seeds, (list, tuple)):
+        items = list(raw_seeds)
+    else:
+        items = [raw_seeds]
+    seeds: List[int] = []
+    for item in items:
+        if item in (None, ""):
+            continue
+        try:
+            seeds.append(int(item))
+        except (TypeError, ValueError) as exc:
+            raise SystemExit(f"Invalid seed value: {item!r}") from exc
+    return seeds
+
+
+def main() -> int:
+    args = parse_args()
+    config_path = Path(args.config).expanduser().resolve()
+    cfg = _load_config(config_path)
+    seeds = _extract_seeds(cfg.get("seeds"))
+    if not seeds:
+        print("xsweep: no seeds in config; nothing to run")
+        return 0
+
+    mode = _resolve_mode(args.mode)
+    trials = _resolve_trials(args.trials)
+
+    rc = 0
+    for seed in seeds:
+        cmd = [
+            sys.executable,
+            RUN_EXPERIMENT.as_posix(),
+            "--config",
+            config_path.as_posix(),
+            "--seed",
+            str(seed),
+            "--trials",
+            str(trials),
+            "--mode",
+            str(mode),
+        ]
+        print("xsweep:", " ".join(cmd))
+        rc |= subprocess.call(cmd)
+    return rc
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- add a dedicated `scripts/xsweep.py` helper that reads experiment seeds, resolves optional overrides, and invokes `run_experiment.py`
- extend `run_experiment.py` so `--mode` and `--trials` can override config values when passed from automation
- update the `xsweep` make target to call the new helper script instead of the inline Python snippet

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68c8871202308329ae4fbc273c6e98b7