### PR TITLE
Update xsweep workflow and CLI overrides

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,13 +11,27 @@ EXP ?= airline_escalating_v1
 MODE ?= SHIM
 
 MODE_ARG :=
+MODE_OVERRIDE :=
 ifneq ($(origin MODE), file)
 MODE_ARG := --mode $(MODE)
+MODE_OVERRIDE := $(MODE)
 endif
 
 TRIALS_ARG :=
+TRIALS_OVERRIDE :=
 ifneq ($(origin TRIALS), file)
 TRIALS_ARG := --trials $(TRIALS)
+TRIALS_OVERRIDE := $(TRIALS)
+endif
+
+SEEDS_OVERRIDE :=
+ifneq ($(origin SEEDS), file)
+SEEDS_OVERRIDE := $(SEEDS)
+endif
+
+EXP_OVERRIDE :=
+ifneq ($(origin EXP), file)
+EXP_OVERRIDE := $(EXP)
 endif
 
 venv:
@@ -44,19 +58,34 @@ sweep:
 	. .venv/bin/activate && python scripts/run_batch.py --exp $(EXP) --seeds "$(SEEDS)" --trials $(TRIALS) --mode $(MODE)
 	$(MAKE) report
 
-
+.ONESHELL: xsweep
 xsweep:
-	if [ -f "$(VENV)/bin/activate" ]; then \
-		. "$(VENV)/bin/activate" && python scripts/xsweep.py --config $(CONFIG) $(MODE_ARG) $(TRIALS_ARG); \
-	else \
-		python scripts/xsweep.py --config $(CONFIG) $(MODE_ARG) $(TRIALS_ARG); \
-	fi
+	if [ -x "$(PY)" ]; then PYTHON_BIN="$(PY)"; else PYTHON_BIN="python"; fi; \
+	CONFIG_PATH="$(CONFIG)" MODE_OVERRIDE="$(MODE_OVERRIDE)" TRIALS_OVERRIDE="$(TRIALS_OVERRIDE)" SEEDS_OVERRIDE="$(SEEDS_OVERRIDE)" EXP_OVERRIDE="$(EXP)" "$${PYTHON_BIN}" - <<-'PY'
+	import os
+	import shlex
+	import subprocess
+	import sys
+	
+	cmd = [sys.executable, "scripts/xsweep.py", "--config", os.environ["CONFIG_PATH"]]
+	seeds_override = os.environ.get("SEEDS_OVERRIDE", "").strip()
+	if seeds_override: cmd.extend(["--seeds", seeds_override])
+	mode_override = os.environ.get("MODE_OVERRIDE", "").strip()
+	if mode_override: cmd.extend(["--mode", mode_override])
+	trials_override = os.environ.get("TRIALS_OVERRIDE", "").strip()
+	if trials_override: cmd.extend(["--trials", trials_override])
+	exp_override = os.environ.get("EXP_OVERRIDE", "").strip()
+	if exp_override: cmd.extend(["--exp", exp_override])
+	
+	print("xsweep:", " ".join(shlex.quote(part) for part in cmd))
+	sys.exit(subprocess.call(cmd))
+	PY
 
 sweep3:
 	$(MAKE) sweep SEEDS="41,42,43" TRIALS=5 MODE=SHIM
 
 aggregate:
-	if [ -x "$(PY)" ]; then \
+		if [ -x "$(PY)" ]; then \
 		"$(PY)" scripts/aggregate_results.py; \
 	else \
 		python scripts/aggregate_results.py; \
@@ -70,7 +99,7 @@ plot:
 	fi
 
 report: aggregate plot
-	if [ -x "$(PY)" ]; then \
+		if [ -x "$(PY)" ]; then \
 		"$(PY)" scripts/update_readme_results.py; \
 	else \
 		python scripts/update_readme_results.py; \

--- a/README.md
+++ b/README.md
@@ -46,7 +46,9 @@ This repo currently uses thin adapters to mirror DoomArena concepts:
 
 | exp | seed | mode | ASR | trials | successes | path |
 | --- | --- | --- | --- | --- | --- | --- |
+| airline_escalating_v1 | 43 | SHIM | 0.60 (3/5) | 5 | 3 | [airline_escalating_v1_seed43](results/airline_escalating_v1/airline_escalating_v1_seed43.jsonl) |
 | airline_escalating_v1 | 42 | SHIM | 0.60 (3/5) | 5 | 3 | [airline_escalating_v1_seed42](results/airline_escalating_v1/airline_escalating_v1_seed42.jsonl) |
+| airline_escalating_v1 | 41 | SHIM | 0.60 (3/5) | 5 | 3 | [airline_escalating_v1_seed41](results/airline_escalating_v1/airline_escalating_v1_seed41.jsonl) |
 
 <!-- RESULTS:END -->
 

--- a/results/summary.csv
+++ b/results/summary.csv
@@ -1,6 +1,4 @@
 timestamp,run_id,git_sha,repo_dirty,exp,seed,mode,trials,successes,asr,py_version,path
-2025-09-15T20:21:07.567853+00:00,2025-09-15T20-21-07Z,52e8ed0,true,airline_escalating_v1,41,SHIM,5,3,0.600000,3.11.12,results/airline_escalating_v1_6f86f87e/seed41.jsonl
-2025-09-15T20:21:08.752160+00:00,2025-09-15T20-21-08Z,52e8ed0,true,airline_escalating_v1,42,SHIM,5,3,0.600000,3.11.12,results/airline_escalating_v1_6f86f87e/seed42.jsonl
-2025-09-15T20:21:09.950723+00:00,2025-09-15T20-21-09Z,52e8ed0,true,airline_escalating_v1,43,SHIM,5,3,0.600000,3.11.12,results/airline_escalating_v1_6f86f87e/seed43.jsonl
-2025-09-15T20:17:34.773490+00:00,2025-09-15T20-17-34Z,52e8ed0,true,airline_escalating_v1,99,SHIM,2,0,0.000000,3.11.12,results/airline_escalating_v1/airline_escalating_v1_seed99.jsonl
-2025-09-15T20:17:35.929309+00:00,2025-09-15T20-17-35Z,52e8ed0,true,airline_escalating_v1,777,SHIM,1,0,0.000000,3.11.12,results/airline_escalating_v1_74a57bcc/seed777.jsonl
+2025-09-15T23:46:15.543516+00:00,2025-09-15T23-46-15Z,4e458f6,true,airline_escalating_v1,41,SHIM,5,3,0.600000,3.11.12,results/airline_escalating_v1/airline_escalating_v1_seed41.jsonl
+2025-09-15T23:46:15.716381+00:00,2025-09-15T23-46-15Z,4e458f6,true,airline_escalating_v1,42,SHIM,5,3,0.600000,3.11.12,results/airline_escalating_v1/airline_escalating_v1_seed42.jsonl
+2025-09-15T23:46:15.886050+00:00,2025-09-15T23-46-15Z,4e458f6,true,airline_escalating_v1,43,SHIM,5,3,0.600000,3.11.12,results/airline_escalating_v1/airline_escalating_v1_seed43.jsonl

--- a/results/summary.md
+++ b/results/summary.md
@@ -1,3 +1,5 @@
 | exp | seed | mode | ASR | trials | successes | path |
 | --- | --- | --- | --- | --- | --- | --- |
+| airline_escalating_v1 | 43 | SHIM | 0.60 (3/5) | 5 | 3 | [airline_escalating_v1_seed43](results/airline_escalating_v1/airline_escalating_v1_seed43.jsonl) |
 | airline_escalating_v1 | 42 | SHIM | 0.60 (3/5) | 5 | 3 | [airline_escalating_v1_seed42](results/airline_escalating_v1/airline_escalating_v1_seed42.jsonl) |
+| airline_escalating_v1 | 41 | SHIM | 0.60 (3/5) | 5 | 3 | [airline_escalating_v1_seed41](results/airline_escalating_v1/airline_escalating_v1_seed41.jsonl) |

--- a/scripts/run_experiment.py
+++ b/scripts/run_experiment.py
@@ -33,17 +33,9 @@ def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Run a single experiment seed")
     parser.add_argument("--config", required=True, help="Path to experiment YAML config")
     parser.add_argument("--seed", type=int, help="Seed override", default=None)
-    parser.add_argument(
-        "--mode",
-        help="Override config mode (e.g. SHIM or REAL)",
-        default=None,
-    )
-    parser.add_argument(
-        "--trials",
-        type=int,
-        help="Override config trials count",
-        default=None,
-    )
+    parser.add_argument("--mode", help="Override config mode (e.g. SHIM or REAL)", default=None)
+    parser.add_argument("--trials", type=int, help="Override config trials count", default=None)
+    parser.add_argument("--exp", help="Override config experiment name", default=None)
     return parser.parse_args()
 
 
@@ -164,7 +156,9 @@ def main() -> None:
     if args.mode is not None:
         cfg["mode"] = args.mode
     if args.trials is not None:
-        cfg["trials"] = args.trials
+        cfg["trials"] = int(args.trials)
+    if args.exp is not None:
+        cfg["exp"] = args.exp
 
     exp = cfg.get("exp")
     if not exp:
@@ -183,8 +177,8 @@ def main() -> None:
     mode = str(cfg.get("mode", "SHIM")).upper()
     trials = int(cfg.get("trials", 0))
 
-    results_dir = Path("results") / f"{exp}_{exp_id}"
-    jsonl_path = results_dir / f"seed{seed}.jsonl"
+    results_dir = Path("results") / str(exp)
+    jsonl_path = results_dir / f"{exp}_seed{seed}.jsonl"
 
     jsonl_path.parent.mkdir(parents=True, exist_ok=True)
     if jsonl_path.exists():

--- a/scripts/xsweep.py
+++ b/scripts/xsweep.py
@@ -1,10 +1,8 @@
 #!/usr/bin/env python3
 """Run each seed listed in a YAML config via ``run_experiment.py``."""
-
 from __future__ import annotations
 
 import argparse
-import os
 import shlex
 import subprocess
 import sys
@@ -13,95 +11,101 @@ from typing import Iterable, List
 
 import yaml
 
-
-def _default_trials() -> int | None:
-    raw = os.environ.get("TRIALS")
-    if raw is None or not raw.strip():
-        return None
-    try:
-        return int(raw)
-    except ValueError:
-        raise SystemExit(f"Invalid TRIALS value: {raw!r}")
+SCRIPT_DIR = Path(__file__).resolve().parent
+RUN_EXPERIMENT = SCRIPT_DIR / "run_experiment.py"
 
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Run configured seeds sequentially")
     parser.add_argument("--config", required=True, help="Path to experiment YAML config")
     parser.add_argument(
+        "--seeds",
+        default=None,
+        help="Comma-separated seed overrides (defaults to config seeds)",
+    )
+    parser.add_argument(
         "--mode",
-        default=os.environ.get("MODE"),
-        help="Override execution mode (defaults to config or $MODE)",
+        default=None,
+        help="Execution mode override passed to run_experiment.py",
     )
     parser.add_argument(
         "--trials",
         type=int,
-        default=_default_trials(),
-        help="Override trials count (defaults to config or $TRIALS)",
+        default=None,
+        help="Trials override passed to run_experiment.py",
+    )
+    parser.add_argument(
+        "--exp",
+        default=None,
+        help="Experiment name override passed to run_experiment.py",
     )
     return parser.parse_args()
 
 
-def _load_config(path: str) -> dict:
-    config_path = Path(path)
-    if not config_path.exists():
+def _load_config(path: Path) -> dict:
+    if not path.exists():
         raise SystemExit(f"Config not found: {path}")
-    with config_path.open("r", encoding="utf-8") as handle:
+    with path.open("r") as handle:
         return yaml.safe_load(handle) or {}
 
 
-def _ensure_int_seeds(raw_seeds: Iterable[object]) -> List[int]:
+def _coerce_seeds(raw: Iterable[int | str] | int | str | None) -> List[int]:
+    if raw is None:
+        return []
+    if isinstance(raw, (list, tuple, set)):
+        items = list(raw)
+    else:
+        items = [raw]
     seeds: List[int] = []
-    for value in raw_seeds:
+    for item in items:
+        text = str(item).strip()
+        if not text:
+            continue
         try:
-            seeds.append(int(value))
-        except (TypeError, ValueError):
-            print(f"xsweep: skipping invalid seed {value!r}", file=sys.stderr)
+            seeds.append(int(text))
+        except (TypeError, ValueError) as exc:
+            raise SystemExit(f"Invalid seed value: {item!r}") from exc
     return seeds
 
 
-def _python_binary() -> str:
-    candidates = [
-        Path(".venv") / "bin" / "python",
-        Path(".venv") / "Scripts" / "python.exe",
-        Path(".venv") / "Scripts" / "python",
-    ]
-    for candidate in candidates:
-        if candidate.exists():
-            return candidate.as_posix()
-    return sys.executable
+def _resolve_seeds(arg: str | None, cfg: dict) -> List[int]:
+    if arg:
+        parts = [segment.strip() for segment in arg.split(",")]
+        return _coerce_seeds([part for part in parts if part])
+    return _coerce_seeds(cfg.get("seeds"))
 
 
 def main() -> int:
     args = parse_args()
-    cfg = _load_config(args.config)
+    config_path = Path(args.config).expanduser().resolve()
+    cfg = _load_config(config_path)
 
-    raw_seeds = cfg.get("seeds") or []
-    if isinstance(raw_seeds, (str, bytes)):
-        raw_seeds = [raw_seeds]
-    seeds = _ensure_int_seeds(raw_seeds)
+    seeds = _resolve_seeds(args.seeds, cfg)
     if not seeds:
         print("xsweep: no seeds in config; nothing to run")
         return 0
 
-    python_bin = _python_binary()
     rc = 0
     for seed in seeds:
         cmd = [
-            python_bin,
-            "scripts/run_experiment.py",
+            sys.executable,
+            RUN_EXPERIMENT.as_posix(),
             "--config",
-            args.config,
+            config_path.as_posix(),
             "--seed",
             str(seed),
         ]
         if args.trials is not None:
-            cmd.extend(["--trials", str(args.trials)])
+            cmd.extend(["--trials", str(int(args.trials))])
         if args.mode:
             cmd.extend(["--mode", str(args.mode)])
+        if args.exp:
+            cmd.extend(["--exp", str(args.exp)])
 
         print("xsweep:", " ".join(shlex.quote(part) for part in cmd))
         completed = subprocess.run(cmd, check=False)
         rc |= completed.returncode
+
     return rc
 
 


### PR DESCRIPTION
## Summary
- rework the `xsweep` Makefile target to call the standalone xsweep runner via a heredoc
- add CLI overrides and new result path handling in `scripts/run_experiment.py`
- update the README and summary outputs with the latest shim run results

## Testing
- make install
- make xsweep CONFIG=configs/airline_escalating_v1/run.yaml SEEDS="41,42,43" TRIALS=5 MODE=SHIM
- make aggregate report

------
https://chatgpt.com/codex/tasks/task_e_68c89e1389848329a8bb375133640112