### PR TITLE
Results: persist meta.json and extend summary.csv

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,16 +48,16 @@ This repo currently uses thin adapters to mirror DoomArena concepts:
 
 | exp | seed | mode | ASR | trials | successes | path |
 | --- | --- | --- | --- | --- | --- | --- |
-| airline_escalating_v1 | 42 | SHIM | 0.60 (3/5) | 5 | 3 | [airline_escalating_seed42](results/airline_escalating_v1/airline_escalating_seed42.jsonl) |
+| airline_escalating_v1 | 42 | SHIM | 0.60 (3/5) | 5 | 3 | [airline_escalating_v1_seed42](results/airline_escalating_v1/airline_escalating_v1_seed42.jsonl) |
 
 <!-- RESULTS:END -->
 
 ### Results schema
 
-`results/summary.csv` is locked to the following header (order matters):
+Each run writes `results/<exp>/meta.json` with execution metadata. `results/summary.csv` includes these fields and is locked to the following header (order matters):
 
 ```
-timestamp,run_id,git_sha,repo_dirty,exp,seed,mode,trials,successes,asr,py_version,path
+timestamp,run_id,git_sha,git_branch,repo_dirty,exp,exp_id,seed,mode,trials,successes,asr,python_version,packages,seeds,path
 ```
 
 Use `make check-schema` to verify the file matches the expected schema.

--- a/results/summary.csv
+++ b/results/summary.csv
@@ -1,2 +1,2 @@
-timestamp,run_id,git_sha,repo_dirty,exp,seed,mode,trials,successes,asr,py_version,path
-2025-09-15T23:46:15.716381+00:00,2025-09-15T23-46-15Z,1488f6f,true,airline_escalating_v1,42,SHIM,5,3,0.600000,3.11.12,results/airline_escalating_v1/airline_escalating_seed42.jsonl
+timestamp,run_id,git_sha,git_branch,repo_dirty,exp,exp_id,seed,mode,trials,successes,asr,python_version,packages,seeds,path
+2025-09-16T06:09:08.512780+00:00,2025-09-16T06-09-08Z,863ba65,work,true,airline_escalating_v1,6f86f87e,42,SHIM,5,3,0.600000,3.11.12,"{""doomarena"": ""n/a"", ""doomarena_taubench"": ""n/a"", ""tau_bench"": ""n/a""}","41,42,43",results/airline_escalating_v1/airline_escalating_v1_seed42.jsonl

--- a/results/summary.md
+++ b/results/summary.md
@@ -1,3 +1,3 @@
 | exp | seed | mode | ASR | trials | successes | path |
 | --- | --- | --- | --- | --- | --- | --- |
-| airline_escalating_v1 | 42 | SHIM | 0.60 (3/5) | 5 | 3 | [airline_escalating_seed42](results/airline_escalating_v1/airline_escalating_seed42.jsonl) |
+| airline_escalating_v1 | 42 | SHIM | 0.60 (3/5) | 5 | 3 | [airline_escalating_v1_seed42](results/airline_escalating_v1/airline_escalating_v1_seed42.jsonl) |

--- a/results/summary.svg
+++ b/results/summary.svg
@@ -6,7 +6,7 @@
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
     <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-    <dc:date>2025-09-16T05:43:38.877222</dc:date>
+    <dc:date>2025-09-16T06:09:57.295941</dc:date>
     <dc:format>image/svg+xml</dc:format>
     <dc:creator>
      <cc:Agent>
@@ -43,18 +43,18 @@ L 400.284886 241.478125
 L 400.284886 109.982125 
 L 60.757614 109.982125 
 z
-" clip-path="url(#p62abd794f8)" style="fill: #4c72b0"/>
+" clip-path="url(#p59408f9b25)" style="fill: #4c72b0"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="m74ff591238" d="M 0 0 
+       <path id="m869a8e094b" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m74ff591238" x="230.52125" y="241.478125" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m869a8e094b" x="230.52125" y="241.478125" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -209,16 +209,16 @@ z
      <g id="line2d_2">
       <path d="M 43.78125 241.478125 
 L 417.26125 241.478125 
-" clip-path="url(#p62abd794f8)" style="fill: none; stroke-dasharray: 2.96,1.28; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.4; stroke-width: 0.8"/>
+" clip-path="url(#p59408f9b25)" style="fill: none; stroke-dasharray: 2.96,1.28; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.4; stroke-width: 0.8"/>
      </g>
      <g id="line2d_3">
       <defs>
-       <path id="md693930c99" d="M 0 0 
+       <path id="m1e02b277df" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#md693930c99" x="43.78125" y="241.478125" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1e02b277df" x="43.78125" y="241.478125" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -264,11 +264,11 @@ z
      <g id="line2d_4">
       <path d="M 43.78125 197.646125 
 L 417.26125 197.646125 
-" clip-path="url(#p62abd794f8)" style="fill: none; stroke-dasharray: 2.96,1.28; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.4; stroke-width: 0.8"/>
+" clip-path="url(#p59408f9b25)" style="fill: none; stroke-dasharray: 2.96,1.28; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.4; stroke-width: 0.8"/>
      </g>
      <g id="line2d_5">
       <g>
-       <use xlink:href="#md693930c99" x="43.78125" y="197.646125" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1e02b277df" x="43.78125" y="197.646125" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -284,11 +284,11 @@ L 417.26125 197.646125
      <g id="line2d_6">
       <path d="M 43.78125 153.814125 
 L 417.26125 153.814125 
-" clip-path="url(#p62abd794f8)" style="fill: none; stroke-dasharray: 2.96,1.28; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.4; stroke-width: 0.8"/>
+" clip-path="url(#p59408f9b25)" style="fill: none; stroke-dasharray: 2.96,1.28; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.4; stroke-width: 0.8"/>
      </g>
      <g id="line2d_7">
       <g>
-       <use xlink:href="#md693930c99" x="43.78125" y="153.814125" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1e02b277df" x="43.78125" y="153.814125" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -304,11 +304,11 @@ L 417.26125 153.814125
      <g id="line2d_8">
       <path d="M 43.78125 109.982125 
 L 417.26125 109.982125 
-" clip-path="url(#p62abd794f8)" style="fill: none; stroke-dasharray: 2.96,1.28; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.4; stroke-width: 0.8"/>
+" clip-path="url(#p59408f9b25)" style="fill: none; stroke-dasharray: 2.96,1.28; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.4; stroke-width: 0.8"/>
      </g>
      <g id="line2d_9">
       <g>
-       <use xlink:href="#md693930c99" x="43.78125" y="109.982125" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1e02b277df" x="43.78125" y="109.982125" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -356,11 +356,11 @@ z
      <g id="line2d_10">
       <path d="M 43.78125 66.150125 
 L 417.26125 66.150125 
-" clip-path="url(#p62abd794f8)" style="fill: none; stroke-dasharray: 2.96,1.28; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.4; stroke-width: 0.8"/>
+" clip-path="url(#p59408f9b25)" style="fill: none; stroke-dasharray: 2.96,1.28; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.4; stroke-width: 0.8"/>
      </g>
      <g id="line2d_11">
       <g>
-       <use xlink:href="#md693930c99" x="43.78125" y="66.150125" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1e02b277df" x="43.78125" y="66.150125" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -417,11 +417,11 @@ z
      <g id="line2d_12">
       <path d="M 43.78125 22.318125 
 L 417.26125 22.318125 
-" clip-path="url(#p62abd794f8)" style="fill: none; stroke-dasharray: 2.96,1.28; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.4; stroke-width: 0.8"/>
+" clip-path="url(#p59408f9b25)" style="fill: none; stroke-dasharray: 2.96,1.28; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.4; stroke-width: 0.8"/>
      </g>
      <g id="line2d_13">
       <g>
-       <use xlink:href="#md693930c99" x="43.78125" y="22.318125" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1e02b277df" x="43.78125" y="22.318125" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -885,7 +885,7 @@ z
   </g>
  </g>
  <defs>
-  <clipPath id="p62abd794f8">
+  <clipPath id="p59408f9b25">
    <rect x="43.78125" y="22.318125" width="373.48" height="219.16"/>
   </clipPath>
  </defs>

--- a/scripts/capture_meta.py
+++ b/scripts/capture_meta.py
@@ -1,0 +1,168 @@
+"""Utilities for capturing experiment metadata alongside results."""
+from __future__ import annotations
+
+import argparse
+import json
+import platform
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Iterable, Mapping, Sequence
+
+try:  # Python 3.8+
+    from importlib import metadata as importlib_metadata
+except ImportError:  # pragma: no cover - Python <3.8 fallback
+    import importlib_metadata  # type: ignore
+
+PACKAGE_LOOKUP: Mapping[str, str] = {
+    "doomarena": "doomarena",
+    "doomarena_taubench": "doomarena-taubench",
+    "tau_bench": "tau-bench",
+}
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _run_git_command(args: Sequence[str]) -> str:
+    try:
+        return (
+            subprocess.check_output(["git", *args], stderr=subprocess.DEVNULL, text=True)
+            .strip()
+        )
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return "unknown"
+
+
+def _git_sha() -> str:
+    return _run_git_command(["rev-parse", "--short", "HEAD"])
+
+
+def _git_branch() -> str:
+    return _run_git_command(["rev-parse", "--abbrev-ref", "HEAD"])
+
+
+def _detect_packages() -> dict[str, str]:
+    versions: dict[str, str] = {}
+    for logical_name, dist_name in PACKAGE_LOOKUP.items():
+        try:
+            versions[logical_name] = importlib_metadata.version(dist_name)
+        except importlib_metadata.PackageNotFoundError:
+            versions[logical_name] = "n/a"
+    return versions
+
+
+def normalize_seeds(seeds: Iterable[object]) -> list[object]:
+    normalized: list[object] = []
+    seen: set[str] = set()
+    for seed in seeds:
+        if seed is None:
+            continue
+        if isinstance(seed, int) and not isinstance(seed, bool):
+            value: object = int(seed)
+        else:
+            text = str(seed).strip()
+            if not text:
+                continue
+            try:
+                value = int(text)
+            except ValueError:
+                value = text
+        key = str(value)
+        if key in seen:
+            continue
+        seen.add(key)
+        normalized.append(value)
+    return normalized
+
+
+def gather_metadata(
+    *, exp_id: str, seeds: Iterable[object], trials: int, mode: str
+) -> dict[str, object]:
+    normalized_seeds = normalize_seeds(seeds)
+    metadata: dict[str, object] = {
+        "exp_id": exp_id,
+        "timestamp": _now_iso(),
+        "seeds": normalized_seeds,
+        "trials": int(trials),
+        "mode": str(mode).upper(),
+        "git_sha": _git_sha(),
+        "git_branch": _git_branch(),
+        "python_version": platform.python_version(),
+        "packages": _detect_packages(),
+    }
+    return metadata
+
+
+def write_meta(
+    exp_dir: Path | str,
+    *,
+    exp_id: str,
+    seeds: Iterable[object],
+    trials: int,
+    mode: str,
+) -> dict[str, object]:
+    target_dir = Path(exp_dir)
+    target_dir.mkdir(parents=True, exist_ok=True)
+    metadata = gather_metadata(exp_id=exp_id, seeds=seeds, trials=trials, mode=mode)
+    meta_path = target_dir / "meta.json"
+    meta_path.write_text(json.dumps(metadata, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return metadata
+
+
+def _parse_seeds_argument(value: str | None) -> list[object]:
+    if not value:
+        return []
+    parts = [part.strip() for part in value.split(",")]
+    return [part for part in parts if part]
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Capture experiment metadata next to results.")
+    parser.add_argument(
+        "--exp-dir",
+        required=True,
+        help="Experiment directory (relative to --results-root) where meta.json will be written.",
+    )
+    parser.add_argument("--exp-id", required=True, help="Unique experiment identifier.")
+    parser.add_argument("--trials", required=True, type=int, help="Number of trials for the run.")
+    parser.add_argument("--mode", default="SHIM", help="Execution mode for the run (e.g. SHIM or REAL).")
+    parser.add_argument(
+        "--seeds",
+        default="",
+        help="Comma-separated list of seeds associated with the experiment run.",
+    )
+    parser.add_argument(
+        "--results-root",
+        default="results",
+        help="Base directory that contains experiment result folders.",
+    )
+    parser.add_argument(
+        "--output",
+        default=None,
+        help="Optional explicit output directory. Overrides --results-root/--exp-dir when provided.",
+    )
+    args = parser.parse_args(argv)
+
+    if args.output:
+        exp_dir = Path(args.output)
+    else:
+        exp_dir = Path(args.results_root) / args.exp_dir
+
+    metadata = write_meta(
+        exp_dir,
+        exp_id=args.exp_id,
+        seeds=_parse_seeds_argument(args.seeds),
+        trials=args.trials,
+        mode=args.mode,
+    )
+    meta_path = Path(exp_dir) / "meta.json"
+    print(meta_path.as_posix())
+    print(json.dumps(metadata, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- add `scripts/capture_meta.py` to capture git, runtime, and package metadata into each experiment's `meta.json`
- update the experiment runner to write metadata alongside JSONL outputs and enrich summary rows with the captured fields
- extend results aggregation and documentation to import metadata from `meta.json` and expose the new columns in `summary.csv`

## Testing
- `make report`


------
https://chatgpt.com/codex/tasks/task_e_68c8faf15ad88329b14cf80cbd526815