### PR TITLE
CI: shim smoke via `make ci` + artifact upload

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -1,0 +1,29 @@
+name: Shim smoke
+on:
+  pull_request:
+  push:
+    branches: ["**"]
+    tags-ignore: ["**"]
+jobs:
+  smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Install deps
+        run: |
+          python -m pip install -U pip
+          pip install -U doomarena doomarena-taubench pytest pyyaml matplotlib
+      - name: Run shim smoke
+        run: make ci
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: doomarena-smoke
+          path: |
+            results/summary.csv
+            results/summary.svg
+            results/**/*.jsonl
+          if-no-files-found: warn

--- a/Makefile
+++ b/Makefile
@@ -118,3 +118,7 @@ journal: install
 .PHONY: install-tau
 install-tau: install
 	$(PY) scripts/ensure_tau_bench.py || (echo "tau_bench unavailable; continuing without real τ-Bench" && exit 0)
+
+.PHONY: ci
+ci:
+	SEEDS_OVERRIDE=41,42 TRIALS_OVERRIDE=3 MODE_OVERRIDE=SHIM $(MAKE) report


### PR DESCRIPTION
## Summary
- add a Makefile `ci` target that runs the report with shim-friendly overrides
- add a shim smoke GitHub Actions workflow that runs `make ci` and uploads summary artifacts

## Testing
- make ci

------
https://chatgpt.com/codex/tasks/task_e_68c90d53a4f88329bd7a0a6b07d6cc34