### PR TITLE
Stamp runs with metadata + upgrade summary.csv (exp_id, cfg_hash, commit)

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,9 +46,11 @@ This repo currently uses thin adapters to mirror DoomArena concepts:
 
 ![Results summary](results/summary.svg)
 
-| exp | seed | mode | ASR | trials | successes | path |
-| --- | --- | --- | --- | --- | --- | --- |
-| airline_escalating_v1 | 42 | SHIM | 0.60 (3/5) | 5 | 3 | [airline_escalating_v1_seed42](results/airline_escalating_v1/airline_escalating_v1_seed42.jsonl) |
+| exp | seeds | mode | ASR | trials | successes | git | run_at |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| airline_escalating_v1 | 43,41,42 | SHIM | 0.60 (3/5) | 5 | 3 | c98ef02d | 2025-09-16T08:01:15.606971Z |
+| airline_escalating_v1 | 42,41,43 | SHIM | 0.60 (3/5) | 5 | 3 | c98ef02d | 2025-09-16T08:01:12.610826Z |
+| airline_escalating_v1 | 41,42,43 | SHIM | 0.60 (3/5) | 5 | 3 | c98ef02d | 2025-09-16T08:01:09.726240Z |
 
 <!-- RESULTS:END -->
 
@@ -57,7 +59,7 @@ This repo currently uses thin adapters to mirror DoomArena concepts:
 Each run writes `results/<exp>/meta.json` with execution metadata. `results/summary.csv` includes these fields and is locked to the following header (order matters):
 
 ```
-timestamp,run_id,git_sha,git_branch,repo_dirty,exp,exp_id,seed,mode,trials,successes,asr,python_version,packages,seeds,path
+exp_id,exp,config,cfg_hash,mode,seeds,trials,successes,asr,git_commit,run_at
 ```
 
 Use `make check-schema` to verify the file matches the expected schema.

--- a/results/summary.csv
+++ b/results/summary.csv
@@ -1,2 +1,4 @@
-timestamp,run_id,git_sha,git_branch,repo_dirty,exp,exp_id,seed,mode,trials,successes,asr,python_version,packages,seeds,path
-2025-09-16T06:09:08.512780+00:00,2025-09-16T06-09-08Z,863ba65,work,true,airline_escalating_v1,6f86f87e,42,SHIM,5,3,0.600000,3.11.12,"{""doomarena"": ""n/a"", ""doomarena_taubench"": ""n/a"", ""tau_bench"": ""n/a""}","41,42,43",results/airline_escalating_v1/airline_escalating_v1_seed42.jsonl
+exp_id,exp,config,cfg_hash,mode,seeds,trials,successes,asr,git_commit,run_at
+airline_escalating_v1:1a1a04db,airline_escalating_v1,configs/airline_escalating_v1/exp.yaml,1a1a04dbc856c92851c80e101c9a246e33da09e6,SHIM,"41,42,43",5,3,0.600000,c98ef02d4c458e578f0191a60aea8b7852379e3d,2025-09-16T08:01:09.726240Z
+airline_escalating_v1:1a1a04db,airline_escalating_v1,configs/airline_escalating_v1/exp.yaml,1a1a04dbc856c92851c80e101c9a246e33da09e6,SHIM,"42,41,43",5,3,0.600000,c98ef02d4c458e578f0191a60aea8b7852379e3d,2025-09-16T08:01:12.610826Z
+airline_escalating_v1:1a1a04db,airline_escalating_v1,configs/airline_escalating_v1/exp.yaml,1a1a04dbc856c92851c80e101c9a246e33da09e6,SHIM,"43,41,42",5,3,0.600000,c98ef02d4c458e578f0191a60aea8b7852379e3d,2025-09-16T08:01:15.606971Z

--- a/results/summary.md
+++ b/results/summary.md
@@ -1,3 +1,5 @@
-| exp | seed | mode | ASR | trials | successes | path |
-| --- | --- | --- | --- | --- | --- | --- |
-| airline_escalating_v1 | 42 | SHIM | 0.60 (3/5) | 5 | 3 | [airline_escalating_v1_seed42](results/airline_escalating_v1/airline_escalating_v1_seed42.jsonl) |
+| exp | seeds | mode | ASR | trials | successes | git | run_at |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| airline_escalating_v1 | 43,41,42 | SHIM | 0.60 (3/5) | 5 | 3 | c98ef02d | 2025-09-16T08:01:15.606971Z |
+| airline_escalating_v1 | 42,41,43 | SHIM | 0.60 (3/5) | 5 | 3 | c98ef02d | 2025-09-16T08:01:12.610826Z |
+| airline_escalating_v1 | 41,42,43 | SHIM | 0.60 (3/5) | 5 | 3 | c98ef02d | 2025-09-16T08:01:09.726240Z |

--- a/scripts/run_meta.py
+++ b/scripts/run_meta.py
@@ -1,0 +1,50 @@
+"""Helpers for collecting run metadata."""
+from __future__ import annotations
+
+import hashlib
+import subprocess
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+
+def _run_git_command(args: list[str]) -> str:
+    try:
+        result = subprocess.check_output(["git", *args], text=True, stderr=subprocess.DEVNULL)
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return "unknown"
+    value = result.strip()
+    return value or "unknown"
+
+
+def git_info() -> dict[str, str]:
+    """Return the current git commit SHA and branch name."""
+    commit = _run_git_command(["rev-parse", "HEAD"])
+    branch = _run_git_command(["rev-parse", "--abbrev-ref", "HEAD"])
+    return {"commit": commit, "branch": branch}
+
+
+def _load_yaml(path: Path) -> Any:
+    with path.open("r", encoding="utf-8") as handle:
+        return yaml.safe_load(handle)
+
+
+def cfg_hash(path: str | Path) -> str:
+    """Return a stable SHA1 hash for the given YAML config file."""
+    cfg_path = Path(path)
+    try:
+        data = _load_yaml(cfg_path)
+    except (OSError, yaml.YAMLError):
+        return "unknown"
+    if data is None:
+        data = {}
+    dumped = yaml.safe_dump(data, sort_keys=True)
+    digest = hashlib.sha1(dumped.encode("utf-8")).hexdigest()
+    return digest
+
+
+def now_iso() -> str:
+    """Return the current UTC time in ISO-8601 format."""
+    return datetime.utcnow().isoformat() + "Z"


### PR DESCRIPTION
## Summary
- add `scripts/run_meta.py` to capture git metadata, config hashes, and timestamps
- write rich JSONL headers from `run_experiment.py` and capture runs via the new helpers
- rewrite the aggregation pipeline to populate the new summary CSV schema and keep README docs in sync
- teach the plotting script to read the new columns

## Testing
- make report EXP=airline_escalating_v1 CONFIG=configs/airline_escalating_v1/run.yaml SEEDS="41,42,43" TRIALS=5 MODE=SHIM

------
https://chatgpt.com/codex/tasks/task_e_68c9142509f48329a31c891d4e4dfc0a