### PR TITLE
CI: harden smoke workflow (restore sweep execution)

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -35,11 +35,11 @@ jobs:
           # minimal deps to run SHIM + plotting + yaml + tests
           pip install -U doomarena doomarena-taubench pytest pyyaml matplotlib
 
-      - name: Smoke: report (SHIM)
+      - name: Smoke: sweep + report (SHIM)
         shell: bash
         run: |
           source .venv/bin/activate
-          make report EXP="$EXP" MODE="$MODE" SEEDS="$SEEDS" TRIALS="$TRIALS"
+          make sweep EXP="$EXP" MODE="$MODE" SEEDS="$SEEDS" TRIALS="$TRIALS"
           echo "---- results/summary.csv (head) ----"
           head -5 results/summary.csv || true
           echo "---- grep ASR from run logs if present ----"


### PR DESCRIPTION
## Summary
- replace the smoke workflow with a hardened job that runs from a virtual environment and uses headless matplotlib settings
- capture the SHIM report output and upload CSV and plot artifacts only when present
- restore the SHIM sweep execution before generating the report so the smoke job continues exercising the runner

## Testing
- GitHub Actions smoke workflow (triggered via this PR)

## CI Results
- Unable to collect the smoke step log tail or artifact list from within this environment; please review the GitHub Actions run for ASR output and uploaded artifacts once it completes.


------
https://chatgpt.com/codex/tasks/task_e_68c944705d0483298eec1da624c3c374