### PR TITLE
Docs: add CI badge + artifacts note

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Smoke](https://github.com/jasonstan/doomarena-quickstart/actions/workflows/smoke.yml/badge.svg)](https://github.com/jasonstan/doomarena-quickstart/actions/workflows/smoke.yml)
+
 # TAUBENCH Airline Scaffold
 
 This repository is a scaffold for the TAUBench Airline example in DoomArena.
@@ -43,6 +45,8 @@ This repo currently uses thin adapters to mirror DoomArena concepts:
 
 ## Results
 <!-- RESULTS:BEGIN -->
+
+**Results & artifacts:** The CI smoke run (SHIM sweep) uploads `results/summary.csv` and `results/summary.png` as build artifacts on every PR. See the latest runs on the **Actions** tab.
 
 ![Results summary](results/summary.svg)
 


### PR DESCRIPTION
## Summary
- add a GitHub Actions smoke workflow badge to the README
- note where CI uploads the summary results artifacts

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68c94664a2908329ba977e034334cf1c