### PR TITLE
CI: cache pip deps for faster smoke

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -25,15 +25,16 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.11"
+          cache: pip
+          cache-dependency-path: requirements-ci.txt
 
       - name: Create venv and install deps
         shell: bash
         run: |
           python -m venv .venv
           source .venv/bin/activate
-          python -m pip install -U pip wheel
-          # minimal deps to run SHIM + plotting + yaml + tests
-          pip install -U doomarena doomarena-taubench pytest pyyaml matplotlib
+          pip install -U pip wheel
+          pip install -r requirements-ci.txt
 
       - name: Smoke: sweep + report (SHIM)
         shell: bash

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -1,0 +1,5 @@
+doomarena
+doomarena-taubench
+pytest
+pyyaml
+matplotlib


### PR DESCRIPTION
## Summary
- add a dedicated requirements-ci.txt file for the smoke workflow
- cache pip dependencies and install from the requirements file during smoke CI

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68c9472a617c832988e542795b1b6804