### PR TITLE
Fix smoke workflow pip cache usage

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -25,8 +25,6 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.11"
-          cache: pip
-          cache-dependency-path: requirements-ci.txt
 
       - name: Create venv and install deps
         shell: bash


### PR DESCRIPTION
## Summary
- remove pip cache configuration from the smoke workflow's Python setup step

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68c94f6fac14832991f17468896b53ca