### PR TITLE
Ensure smoke workflow runs for dependency updates

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -8,6 +8,10 @@ on:
       - 'Makefile'
       - 'scripts/**'
       - 'configs/**'
+      - 'requirements*.txt'
+      - '**/requirements*.txt'
+      - '**/pyproject.toml'
+      - '**/poetry.lock'
       - '.github/workflows/smoke.yml'
   workflow_dispatch:
 


### PR DESCRIPTION
## Summary
- include dependency manifest changes in the smoke workflow's pull request path filter so dependency updates still trigger smoke

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68c95883b7c48329b29ff31c60c8dfd8