### PR TITLE
Weight ASR bars by total trials

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,13 @@ This repo currently uses thin adapters to mirror DoomArena concepts:
 **Next step:** replace these adapters with the real DoomArena/τ-Bench classes and keep the same CLI + JSONL outputs so experiment configs remain unchanged.
 
 ## Results
+
+### Results plot
+
+The grouped ASR bars report the overall attack success rate per experiment as total
+successes divided by total trials (a trial-weighted micro average), so experiments
+with more trials carry proportionally more weight in the chart.
+
 <!-- RESULTS:BEGIN -->
 
 ![Results summary](results/summary.svg)

--- a/results/summary.svg
+++ b/results/summary.svg
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
   "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="496.46125pt" height="279.518958pt" viewBox="0 0 496.46125 279.518958" xmlns="http://www.w3.org/2000/svg" version="1.1">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="462.24pt" height="284.878125pt" viewBox="0 0 462.24 284.878125" xmlns="http://www.w3.org/2000/svg" version="1.1">
  <metadata>
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
     <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-    <dc:date>2025-09-16T17:14:22.526343</dc:date>
+    <dc:date>2025-09-16T18:13:16.395539</dc:date>
     <dc:format>image/svg+xml</dc:format>
     <dc:creator>
      <cc:Agent>
@@ -21,196 +21,53 @@
  </defs>
  <g id="figure_1">
   <g id="patch_1">
-   <path d="M 0 279.518958 
-L 496.46125 279.518958 
-L 496.46125 0 
+   <path d="M 0 284.878125 
+L 462.24 284.878125 
+L 462.24 0 
 L 0 0 
 z
 " style="fill: #ffffff"/>
   </g>
   <g id="axes_1">
    <g id="patch_2">
-    <path d="M 43.78125 220.179286 
-L 489.26125 220.179286 
-L 489.26125 22.318125 
-L 43.78125 22.318125 
+    <path d="M 45.56 220.179286 
+L 455.04 220.179286 
+L 455.04 22.318125 
+L 45.56 22.318125 
 z
 " style="fill: #ffffff"/>
    </g>
    <g id="patch_3">
-    <path d="M 64.030341 220.179286 
-L 157.487684 220.179286 
-L 157.487684 220.179286 
-L 64.030341 220.179286 
+    <path d="M 64.172727 220.179286 
+L 203.768182 220.179286 
+L 203.768182 154.225565 
+L 64.172727 154.225565 
 z
-" clip-path="url(#pc6a460b18a)" style="fill: #1f77b4"/>
+" clip-path="url(#pd5433fe9d9)" style="fill: #1f77b4"/>
    </g>
    <g id="patch_4">
-    <path d="M 219.792579 220.179286 
-L 313.249921 220.179286 
-L 313.249921 154.225631 
-L 219.792579 154.225631 
+    <path d="M 296.831818 220.179286 
+L 436.427273 220.179286 
+L 436.427273 154.225565 
+L 296.831818 154.225565 
 z
-" clip-path="url(#pc6a460b18a)" style="fill: #1f77b4"/>
-   </g>
-   <g id="patch_5">
-    <path d="M 375.554816 220.179286 
-L 469.012159 220.179286 
-L 469.012159 154.225631 
-L 375.554816 154.225631 
-z
-" clip-path="url(#pc6a460b18a)" style="fill: #1f77b4"/>
+" clip-path="url(#pd5433fe9d9)" style="fill: #1f77b4"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="m5d9597bfcb" d="M 0 0 
+       <path id="mb76fffeb1a" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m5d9597bfcb" x="110.759012" y="220.179286" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb76fffeb1a" x="133.970455" y="220.179286" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
-      <!-- &lt;unknown&gt; -->
-      <g transform="translate(51.601773 255.592065) rotate(-20) scale(0.1 -0.1)">
-       <defs>
-        <path id="DejaVuSans-3c" d="M 4684 3150 
-L 1459 2003 
-L 4684 863 
-L 4684 294 
-L 678 1747 
-L 678 2266 
-L 4684 3719 
-L 4684 3150 
-z
-" transform="scale(0.015625)"/>
-        <path id="DejaVuSans-75" d="M 544 1381 
-L 544 3500 
-L 1119 3500 
-L 1119 1403 
-Q 1119 906 1312 657 
-Q 1506 409 1894 409 
-Q 2359 409 2629 706 
-Q 2900 1003 2900 1516 
-L 2900 3500 
-L 3475 3500 
-L 3475 0 
-L 2900 0 
-L 2900 538 
-Q 2691 219 2414 64 
-Q 2138 -91 1772 -91 
-Q 1169 -91 856 284 
-Q 544 659 544 1381 
-z
-M 1991 3584 
-L 1991 3584 
-z
-" transform="scale(0.015625)"/>
-        <path id="DejaVuSans-6e" d="M 3513 2113 
-L 3513 0 
-L 2938 0 
-L 2938 2094 
-Q 2938 2591 2744 2837 
-Q 2550 3084 2163 3084 
-Q 1697 3084 1428 2787 
-Q 1159 2491 1159 1978 
-L 1159 0 
-L 581 0 
-L 581 3500 
-L 1159 3500 
-L 1159 2956 
-Q 1366 3272 1645 3428 
-Q 1925 3584 2291 3584 
-Q 2894 3584 3203 3211 
-Q 3513 2838 3513 2113 
-z
-" transform="scale(0.015625)"/>
-        <path id="DejaVuSans-6b" d="M 581 4863 
-L 1159 4863 
-L 1159 1991 
-L 2875 3500 
-L 3609 3500 
-L 1753 1863 
-L 3688 0 
-L 2938 0 
-L 1159 1709 
-L 1159 0 
-L 581 0 
-L 581 4863 
-z
-" transform="scale(0.015625)"/>
-        <path id="DejaVuSans-6f" d="M 1959 3097 
-Q 1497 3097 1228 2736 
-Q 959 2375 959 1747 
-Q 959 1119 1226 758 
-Q 1494 397 1959 397 
-Q 2419 397 2687 759 
-Q 2956 1122 2956 1747 
-Q 2956 2369 2687 2733 
-Q 2419 3097 1959 3097 
-z
-M 1959 3584 
-Q 2709 3584 3137 3096 
-Q 3566 2609 3566 1747 
-Q 3566 888 3137 398 
-Q 2709 -91 1959 -91 
-Q 1206 -91 779 398 
-Q 353 888 353 1747 
-Q 353 2609 779 3096 
-Q 1206 3584 1959 3584 
-z
-" transform="scale(0.015625)"/>
-        <path id="DejaVuSans-77" d="M 269 3500 
-L 844 3500 
-L 1563 769 
-L 2278 3500 
-L 2956 3500 
-L 3675 769 
-L 4391 3500 
-L 4966 3500 
-L 4050 0 
-L 3372 0 
-L 2619 2869 
-L 1863 0 
-L 1184 0 
-L 269 3500 
-z
-" transform="scale(0.015625)"/>
-        <path id="DejaVuSans-3e" d="M 678 3150 
-L 678 3719 
-L 4684 2266 
-L 4684 1747 
-L 678 294 
-L 678 863 
-L 3897 2003 
-L 678 3150 
-z
-" transform="scale(0.015625)"/>
-       </defs>
-       <use xlink:href="#DejaVuSans-3c"/>
-       <use xlink:href="#DejaVuSans-75" transform="translate(83.789062 0)"/>
-       <use xlink:href="#DejaVuSans-6e" transform="translate(147.167969 0)"/>
-       <use xlink:href="#DejaVuSans-6b" transform="translate(210.546875 0)"/>
-       <use xlink:href="#DejaVuSans-6e" transform="translate(268.457031 0)"/>
-       <use xlink:href="#DejaVuSans-6f" transform="translate(331.835938 0)"/>
-       <use xlink:href="#DejaVuSans-77" transform="translate(393.017578 0)"/>
-       <use xlink:href="#DejaVuSans-6e" transform="translate(474.804688 0)"/>
-       <use xlink:href="#DejaVuSans-3e" transform="translate(538.183594 0)"/>
-      </g>
-     </g>
-    </g>
-    <g id="xtick_2">
-     <g id="line2d_2">
-      <g>
-       <use xlink:href="#m5d9597bfcb" x="266.52125" y="220.179286" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_2">
       <!-- airline_escalating_v1 -->
-      <g transform="translate(167.39949 270.103339) rotate(-20) scale(0.1 -0.1)">
+      <g transform="translate(34.848695 270.103339) rotate(-20) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-61" d="M 2194 1759 
 Q 1497 1759 1228 1600 
@@ -280,6 +137,25 @@ L 1178 4863
 L 1178 0 
 L 603 0 
 L 603 4863 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-6e" d="M 3513 2113 
+L 3513 0 
+L 2938 0 
+L 2938 2094 
+Q 2938 2591 2744 2837 
+Q 2550 3084 2163 3084 
+Q 1697 3084 1428 2787 
+Q 1159 2491 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1366 3272 1645 3428 
+Q 1925 3584 2291 3584 
+Q 2894 3584 3203 3211 
+Q 3513 2838 3513 2113 
 z
 " transform="scale(0.015625)"/>
         <path id="DejaVuSans-65" d="M 3597 1894 
@@ -470,15 +346,15 @@ z
       </g>
      </g>
     </g>
-    <g id="xtick_3">
-     <g id="line2d_3">
+    <g id="xtick_2">
+     <g id="line2d_2">
       <g>
-       <use xlink:href="#m5d9597bfcb" x="422.283488" y="220.179286" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb76fffeb1a" x="366.629545" y="220.179286" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
-     <g id="text_3">
+     <g id="text_2">
       <!-- airline_static_v1 -->
-      <g transform="translate(345.549905 261.954709) rotate(-20) scale(0.1 -0.1)">
+      <g transform="translate(289.895962 261.954709) rotate(-20) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-61"/>
        <use xlink:href="#DejaVuSans-69" transform="translate(61.279297 0)"/>
        <use xlink:href="#DejaVuSans-72" transform="translate(89.0625 0)"/>
@@ -502,24 +378,24 @@ z
    </g>
    <g id="matplotlib.axis_2">
     <g id="ytick_1">
-     <g id="line2d_4">
-      <path d="M 43.78125 220.179286 
-L 489.26125 220.179286 
-" clip-path="url(#pc6a460b18a)" style="fill: none; stroke-dasharray: 2.96,1.28; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.4; stroke-width: 0.8"/>
+     <g id="line2d_3">
+      <path d="M 45.56 220.179286 
+L 455.04 220.179286 
+" clip-path="url(#pd5433fe9d9)" style="fill: none; stroke-dasharray: 2.96,1.28; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.4; stroke-width: 0.8"/>
      </g>
-     <g id="line2d_5">
+     <g id="line2d_4">
       <defs>
-       <path id="mf2079314ad" d="M 0 0 
+       <path id="mf2e5212342" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mf2079314ad" x="43.78125" y="220.179286" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf2e5212342" x="45.56" y="220.179286" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
-     <g id="text_4">
+     <g id="text_3">
       <!-- 0.0 -->
-      <g transform="translate(20.878125 223.978504) scale(0.1 -0.1)">
+      <g transform="translate(22.656875 223.978504) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-30" d="M 2034 4250 
 Q 1547 4250 1301 3770 
@@ -557,19 +433,19 @@ z
      </g>
     </g>
     <g id="ytick_2">
-     <g id="line2d_6">
-      <path d="M 43.78125 180.607054 
-L 489.26125 180.607054 
-" clip-path="url(#pc6a460b18a)" style="fill: none; stroke-dasharray: 2.96,1.28; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.4; stroke-width: 0.8"/>
+     <g id="line2d_5">
+      <path d="M 45.56 180.607054 
+L 455.04 180.607054 
+" clip-path="url(#pd5433fe9d9)" style="fill: none; stroke-dasharray: 2.96,1.28; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.4; stroke-width: 0.8"/>
      </g>
-     <g id="line2d_7">
+     <g id="line2d_6">
       <g>
-       <use xlink:href="#mf2079314ad" x="43.78125" y="180.607054" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf2e5212342" x="45.56" y="180.607054" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
-     <g id="text_5">
+     <g id="text_4">
       <!-- 0.2 -->
-      <g transform="translate(20.878125 184.406272) scale(0.1 -0.1)">
+      <g transform="translate(22.656875 184.406272) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-32" d="M 1228 531 
 L 3431 531 
@@ -603,19 +479,19 @@ z
      </g>
     </g>
     <g id="ytick_3">
-     <g id="line2d_8">
-      <path d="M 43.78125 141.034821 
-L 489.26125 141.034821 
-" clip-path="url(#pc6a460b18a)" style="fill: none; stroke-dasharray: 2.96,1.28; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.4; stroke-width: 0.8"/>
+     <g id="line2d_7">
+      <path d="M 45.56 141.034821 
+L 455.04 141.034821 
+" clip-path="url(#pd5433fe9d9)" style="fill: none; stroke-dasharray: 2.96,1.28; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.4; stroke-width: 0.8"/>
      </g>
-     <g id="line2d_9">
+     <g id="line2d_8">
       <g>
-       <use xlink:href="#mf2079314ad" x="43.78125" y="141.034821" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf2e5212342" x="45.56" y="141.034821" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
-     <g id="text_6">
+     <g id="text_5">
       <!-- 0.4 -->
-      <g transform="translate(20.878125 144.83404) scale(0.1 -0.1)">
+      <g transform="translate(22.656875 144.83404) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-34" d="M 2419 4116 
 L 825 1625 
@@ -644,19 +520,19 @@ z
      </g>
     </g>
     <g id="ytick_4">
-     <g id="line2d_10">
-      <path d="M 43.78125 101.462589 
-L 489.26125 101.462589 
-" clip-path="url(#pc6a460b18a)" style="fill: none; stroke-dasharray: 2.96,1.28; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.4; stroke-width: 0.8"/>
+     <g id="line2d_9">
+      <path d="M 45.56 101.462589 
+L 455.04 101.462589 
+" clip-path="url(#pd5433fe9d9)" style="fill: none; stroke-dasharray: 2.96,1.28; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.4; stroke-width: 0.8"/>
      </g>
-     <g id="line2d_11">
+     <g id="line2d_10">
       <g>
-       <use xlink:href="#mf2079314ad" x="43.78125" y="101.462589" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf2e5212342" x="45.56" y="101.462589" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
-     <g id="text_7">
+     <g id="text_6">
       <!-- 0.6 -->
-      <g transform="translate(20.878125 105.261808) scale(0.1 -0.1)">
+      <g transform="translate(22.656875 105.261808) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-36" d="M 2113 2584 
 Q 1688 2584 1439 2293 
@@ -696,19 +572,19 @@ z
      </g>
     </g>
     <g id="ytick_5">
-     <g id="line2d_12">
-      <path d="M 43.78125 61.890357 
-L 489.26125 61.890357 
-" clip-path="url(#pc6a460b18a)" style="fill: none; stroke-dasharray: 2.96,1.28; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.4; stroke-width: 0.8"/>
+     <g id="line2d_11">
+      <path d="M 45.56 61.890357 
+L 455.04 61.890357 
+" clip-path="url(#pd5433fe9d9)" style="fill: none; stroke-dasharray: 2.96,1.28; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.4; stroke-width: 0.8"/>
      </g>
-     <g id="line2d_13">
+     <g id="line2d_12">
       <g>
-       <use xlink:href="#mf2079314ad" x="43.78125" y="61.890357" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf2e5212342" x="45.56" y="61.890357" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
-     <g id="text_8">
+     <g id="text_7">
       <!-- 0.8 -->
-      <g transform="translate(20.878125 65.689576) scale(0.1 -0.1)">
+      <g transform="translate(22.656875 65.689576) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-38" d="M 2034 2216 
 Q 1584 2216 1326 1975 
@@ -757,28 +633,28 @@ z
      </g>
     </g>
     <g id="ytick_6">
-     <g id="line2d_14">
-      <path d="M 43.78125 22.318125 
-L 489.26125 22.318125 
-" clip-path="url(#pc6a460b18a)" style="fill: none; stroke-dasharray: 2.96,1.28; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.4; stroke-width: 0.8"/>
+     <g id="line2d_13">
+      <path d="M 45.56 22.318125 
+L 455.04 22.318125 
+" clip-path="url(#pd5433fe9d9)" style="fill: none; stroke-dasharray: 2.96,1.28; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.4; stroke-width: 0.8"/>
      </g>
-     <g id="line2d_15">
+     <g id="line2d_14">
       <g>
-       <use xlink:href="#mf2079314ad" x="43.78125" y="22.318125" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf2e5212342" x="45.56" y="22.318125" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
-     <g id="text_9">
+     <g id="text_8">
       <!-- 1.0 -->
-      <g transform="translate(20.878125 26.117344) scale(0.1 -0.1)">
+      <g transform="translate(22.656875 26.117344) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-31"/>
        <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
        <use xlink:href="#DejaVuSans-30" transform="translate(95.410156 0)"/>
       </g>
      </g>
     </g>
-    <g id="text_10">
-     <!-- ASR -->
-     <g transform="translate(14.798438 131.317455) rotate(-90) scale(0.1 -0.1)">
+    <g id="text_9">
+     <!-- ASR (successes ÷ trials) -->
+     <g transform="translate(16.577188 181.877612) rotate(-90) scale(0.1 -0.1)">
       <defs>
        <path id="DejaVuSans-41" d="M 2188 4044 
 L 1331 1722 
@@ -855,38 +731,140 @@ Q 2509 4147 2053 4147
 L 1259 4147 
 z
 " transform="scale(0.015625)"/>
+       <path id="DejaVuSans-20" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-28" d="M 1984 4856 
+Q 1566 4138 1362 3434 
+Q 1159 2731 1159 2009 
+Q 1159 1288 1364 580 
+Q 1569 -128 1984 -844 
+L 1484 -844 
+Q 1016 -109 783 600 
+Q 550 1309 550 2009 
+Q 550 2706 781 3412 
+Q 1013 4119 1484 4856 
+L 1984 4856 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-75" d="M 544 1381 
+L 544 3500 
+L 1119 3500 
+L 1119 1403 
+Q 1119 906 1312 657 
+Q 1506 409 1894 409 
+Q 2359 409 2629 706 
+Q 2900 1003 2900 1516 
+L 2900 3500 
+L 3475 3500 
+L 3475 0 
+L 2900 0 
+L 2900 538 
+Q 2691 219 2414 64 
+Q 2138 -91 1772 -91 
+Q 1169 -91 856 284 
+Q 544 659 544 1381 
+z
+M 1991 3584 
+L 1991 3584 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-f7" d="M 2297 3547 
+L 3066 3547 
+L 3066 2778 
+L 2297 2778 
+L 2297 3547 
+z
+M 2297 1234 
+L 3066 1234 
+L 3066 469 
+L 2297 469 
+L 2297 1234 
+z
+M 678 2272 
+L 4684 2272 
+L 4684 1741 
+L 678 1741 
+L 678 2272 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-29" d="M 513 4856 
+L 1013 4856 
+Q 1481 4119 1714 3412 
+Q 1947 2706 1947 2009 
+Q 1947 1309 1714 600 
+Q 1481 -109 1013 -844 
+L 513 -844 
+Q 928 -128 1133 580 
+Q 1338 1288 1338 2009 
+Q 1338 2731 1133 3434 
+Q 928 4138 513 4856 
+z
+" transform="scale(0.015625)"/>
       </defs>
       <use xlink:href="#DejaVuSans-41"/>
       <use xlink:href="#DejaVuSans-53" transform="translate(68.408203 0)"/>
       <use xlink:href="#DejaVuSans-52" transform="translate(131.884766 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(201.367188 0)"/>
+      <use xlink:href="#DejaVuSans-28" transform="translate(233.154297 0)"/>
+      <use xlink:href="#DejaVuSans-73" transform="translate(272.167969 0)"/>
+      <use xlink:href="#DejaVuSans-75" transform="translate(324.267578 0)"/>
+      <use xlink:href="#DejaVuSans-63" transform="translate(387.646484 0)"/>
+      <use xlink:href="#DejaVuSans-63" transform="translate(442.626953 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(497.607422 0)"/>
+      <use xlink:href="#DejaVuSans-73" transform="translate(559.130859 0)"/>
+      <use xlink:href="#DejaVuSans-73" transform="translate(611.230469 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(663.330078 0)"/>
+      <use xlink:href="#DejaVuSans-73" transform="translate(724.853516 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(776.953125 0)"/>
+      <use xlink:href="#DejaVuSans-f7" transform="translate(808.740234 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(892.529297 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(924.316406 0)"/>
+      <use xlink:href="#DejaVuSans-72" transform="translate(963.525391 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(1004.638672 0)"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(1032.421875 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(1093.701172 0)"/>
+      <use xlink:href="#DejaVuSans-73" transform="translate(1121.484375 0)"/>
+      <use xlink:href="#DejaVuSans-29" transform="translate(1173.583984 0)"/>
      </g>
     </g>
    </g>
+   <g id="patch_5">
+    <path d="M 45.56 220.179286 
+L 45.56 22.318125 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
    <g id="patch_6">
-    <path d="M 43.78125 220.179286 
-L 43.78125 22.318125 
+    <path d="M 455.04 220.179286 
+L 455.04 22.318125 
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="patch_7">
-    <path d="M 489.26125 220.179286 
-L 489.26125 22.318125 
+    <path d="M 45.56 220.179286 
+L 455.04 220.179286 
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="patch_8">
-    <path d="M 43.78125 220.179286 
-L 489.26125 220.179286 
+    <path d="M 45.56 22.318125 
+L 455.04 22.318125 
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
-   <g id="patch_9">
-    <path d="M 43.78125 22.318125 
-L 489.26125 22.318125 
-" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
-   </g>
-   <g id="text_11">
+   <g id="text_10">
     <!-- Attack Success Rate by Experiment -->
-    <g transform="translate(159.80375 16.318125) scale(0.12 -0.12)">
+    <g transform="translate(143.5825 16.318125) scale(0.12 -0.12)">
      <defs>
-      <path id="DejaVuSans-20" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-6b" d="M 581 4863 
+L 1159 4863 
+L 1159 1991 
+L 2875 3500 
+L 3609 3500 
+L 1753 1863 
+L 3688 0 
+L 2938 0 
+L 1159 1709 
+L 1159 0 
+L 581 0 
+L 581 4863 
+z
+" transform="scale(0.015625)"/>
       <path id="DejaVuSans-62" d="M 3116 1747 
 Q 3116 2381 2855 2742 
 Q 2594 3103 2138 3103 
@@ -1053,10 +1031,180 @@ z
     </g>
    </g>
   </g>
+  <g id="text_11">
+   <!-- Bars are weighted by total trials per experiment. -->
+   <g style="fill: #4c4c4c" transform="translate(7.2 276.014375) scale(0.08 -0.08)">
+    <defs>
+     <path id="DejaVuSans-42" d="M 1259 2228 
+L 1259 519 
+L 2272 519 
+Q 2781 519 3026 730 
+Q 3272 941 3272 1375 
+Q 3272 1813 3026 2020 
+Q 2781 2228 2272 2228 
+L 1259 2228 
+z
+M 1259 4147 
+L 1259 2741 
+L 2194 2741 
+Q 2656 2741 2882 2914 
+Q 3109 3088 3109 3444 
+Q 3109 3797 2882 3972 
+Q 2656 4147 2194 4147 
+L 1259 4147 
+z
+M 628 4666 
+L 2241 4666 
+Q 2963 4666 3353 4366 
+Q 3744 4066 3744 3513 
+Q 3744 3084 3544 2831 
+Q 3344 2578 2956 2516 
+Q 3422 2416 3680 2098 
+Q 3938 1781 3938 1306 
+Q 3938 681 3513 340 
+Q 3088 0 2303 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-77" d="M 269 3500 
+L 844 3500 
+L 1563 769 
+L 2278 3500 
+L 2956 3500 
+L 3675 769 
+L 4391 3500 
+L 4966 3500 
+L 4050 0 
+L 3372 0 
+L 2619 2869 
+L 1863 0 
+L 1184 0 
+L 269 3500 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-68" d="M 3513 2113 
+L 3513 0 
+L 2938 0 
+L 2938 2094 
+Q 2938 2591 2744 2837 
+Q 2550 3084 2163 3084 
+Q 1697 3084 1428 2787 
+Q 1159 2491 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 4863 
+L 1159 4863 
+L 1159 2956 
+Q 1366 3272 1645 3428 
+Q 1925 3584 2291 3584 
+Q 2894 3584 3203 3211 
+Q 3513 2838 3513 2113 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-64" d="M 2906 2969 
+L 2906 4863 
+L 3481 4863 
+L 3481 0 
+L 2906 0 
+L 2906 525 
+Q 2725 213 2448 61 
+Q 2172 -91 1784 -91 
+Q 1150 -91 751 415 
+Q 353 922 353 1747 
+Q 353 2572 751 3078 
+Q 1150 3584 1784 3584 
+Q 2172 3584 2448 3432 
+Q 2725 3281 2906 2969 
+z
+M 947 1747 
+Q 947 1113 1208 752 
+Q 1469 391 1925 391 
+Q 2381 391 2643 752 
+Q 2906 1113 2906 1747 
+Q 2906 2381 2643 2742 
+Q 2381 3103 1925 3103 
+Q 1469 3103 1208 2742 
+Q 947 2381 947 1747 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-6f" d="M 1959 3097 
+Q 1497 3097 1228 2736 
+Q 959 2375 959 1747 
+Q 959 1119 1226 758 
+Q 1494 397 1959 397 
+Q 2419 397 2687 759 
+Q 2956 1122 2956 1747 
+Q 2956 2369 2687 2733 
+Q 2419 3097 1959 3097 
+z
+M 1959 3584 
+Q 2709 3584 3137 3096 
+Q 3566 2609 3566 1747 
+Q 3566 888 3137 398 
+Q 2709 -91 1959 -91 
+Q 1206 -91 779 398 
+Q 353 888 353 1747 
+Q 353 2609 779 3096 
+Q 1206 3584 1959 3584 
+z
+" transform="scale(0.015625)"/>
+    </defs>
+    <use xlink:href="#DejaVuSans-42"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(68.603516 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(129.882812 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(170.996094 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(223.095703 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(254.882812 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(316.162109 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(355.025391 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(416.548828 0)"/>
+    <use xlink:href="#DejaVuSans-77" transform="translate(448.335938 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(530.123047 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(591.646484 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(619.429688 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(682.90625 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(746.285156 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(785.494141 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(847.017578 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(910.494141 0)"/>
+    <use xlink:href="#DejaVuSans-62" transform="translate(942.28125 0)"/>
+    <use xlink:href="#DejaVuSans-79" transform="translate(1005.757812 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(1064.9375 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(1096.724609 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(1135.933594 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(1197.115234 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(1236.324219 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(1297.603516 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(1325.386719 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(1357.173828 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(1396.382812 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(1437.496094 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(1465.279297 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(1526.558594 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(1554.341797 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(1606.441406 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(1638.228516 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(1701.705078 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(1763.228516 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(1804.341797 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(1836.128906 0)"/>
+    <use xlink:href="#DejaVuSans-78" transform="translate(1895.902344 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(1955.082031 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(2018.558594 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(2080.082031 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(2121.195312 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(2148.978516 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(2246.390625 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(2307.914062 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(2371.292969 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(2410.501953 0)"/>
+   </g>
+  </g>
  </g>
  <defs>
-  <clipPath id="pc6a460b18a">
-   <rect x="43.78125" y="22.318125" width="445.48" height="197.861161"/>
+  <clipPath id="pd5433fe9d9">
+   <rect x="45.56" y="22.318125" width="409.48" height="197.861161"/>
   </clipPath>
  </defs>
 </svg>

--- a/scripts/plot_results.py
+++ b/scripts/plot_results.py
@@ -5,21 +5,32 @@ import matplotlib
 
 matplotlib.use("Agg")
 import matplotlib.pyplot as plt
-import csv, pathlib, statistics
-from collections import defaultdict
 import argparse
+import csv
+import math
+import pathlib
 import sys
-from typing import Dict, List, Optional, Tuple
+from collections import defaultdict
+from dataclasses import dataclass
+from typing import Dict, Iterable, List, Optional
 
 CSV = pathlib.Path("results/summary.csv")
 OUT_SVG = pathlib.Path("results/summary.svg")
 OUT_PNG = pathlib.Path("results/summary.png")
 
 
-def load_rows(csv_path: pathlib.Path) -> List[Tuple[str, float]]:
-    """Return ``(experiment, asr)`` rows from the CSV, normalising headers."""
+@dataclass
+class SummaryRow:
+    exp: str
+    asr: Optional[float]
+    trials: Optional[float]
+    successes: Optional[float]
 
-    rows: List[Tuple[str, float]] = []
+
+def load_rows(csv_path: pathlib.Path) -> List[SummaryRow]:
+    """Return rows from the CSV with normalised headers."""
+
+    rows: List[SummaryRow] = []
     with csv_path.open(newline="") as handle:
         reader = csv.DictReader(handle)
         if reader.fieldnames is None:
@@ -36,37 +47,73 @@ def load_rows(csv_path: pathlib.Path) -> List[Tuple[str, float]]:
             if "exp" not in normalised:
                 continue
 
+            exp_value = normalised.get("exp", "")
+            exp_text = str(exp_value).strip() if exp_value is not None else ""
+            if not exp_text:
+                exp_text = "<unknown>"
             asr_source: Optional[object]
             if "asr" in normalised:
                 asr_source = normalised["asr"]
             else:
                 asr_source = normalised.get("attack_success_rate")
-            if asr_source is None:
-                continue
 
-            try:
-                asr_value = float(asr_source)
-            except (TypeError, ValueError):
-                continue
+            def parse_optional_float(value: Optional[object]) -> Optional[float]:
+                if value is None:
+                    return None
+                if isinstance(value, str):
+                    value = value.strip()
+                    if not value:
+                        return None
+                try:
+                    parsed = float(value)
+                except (TypeError, ValueError):
+                    return None
+                if math.isnan(parsed):
+                    return None
+                return parsed
 
-            exp_value = normalised.get("exp", "")
-            exp_text = str(exp_value).strip() if exp_value is not None else ""
-            if not exp_text:
-                exp_text = "<unknown>"
-            rows.append((exp_text, asr_value))
+            asr_value = parse_optional_float(asr_source)
+            trials_value = parse_optional_float(normalised.get("trials"))
+            successes_value = parse_optional_float(normalised.get("successes"))
+
+            rows.append(
+                SummaryRow(
+                    exp=exp_text,
+                    asr=asr_value,
+                    trials=trials_value,
+                    successes=successes_value,
+                )
+            )
     return rows
 
 
-def aggregate_means(rows: List[Tuple[str, float]]) -> Tuple[List[str], List[float]]:
-    """Aggregate mean ASR per experiment name."""
+def weighted_asr_by_exp(rows: Iterable[SummaryRow]) -> Dict[str, float]:
+    """Compute trial-weighted ASR per experiment.
 
-    grouped: Dict[str, List[float]] = defaultdict(list)
-    for exp, asr in rows:
-        grouped[exp].append(asr)
+    Uses total successes / total trials when available, falling back to
+    sum(asr * trials) / sum(trials) if successes is missing.
+    """
 
-    experiments = sorted(grouped.keys())
-    means = [statistics.fmean(grouped[exp]) for exp in experiments]
-    return experiments, means
+    totals_succ: Dict[str, float] = defaultdict(float)
+    totals_trials: Dict[str, float] = defaultdict(float)
+
+    for row in rows:
+        exp = row.exp or ""
+        trials = row.trials
+        if trials is None:
+            continue
+
+        totals_trials[exp] += float(trials)
+
+        if row.successes is not None:
+            totals_succ[exp] += float(row.successes)
+        elif row.asr is not None:
+            totals_succ[exp] += float(row.asr) * float(trials)
+
+    return {
+        exp: (totals_succ[exp] / total_trials) if total_trials else float("nan")
+        for exp, total_trials in totals_trials.items()
+    }
 
 
 def plot_summary(experiments: List[str], means: List[float]) -> None:
@@ -81,11 +128,21 @@ def plot_summary(experiments: List[str], means: List[float]) -> None:
     ax.bar(positions, means, width=0.6)
 
     ax.set_ylim(0.0, 1.0)
-    ax.set_ylabel("ASR")
+    ax.set_ylabel("ASR (successes ÷ trials)")
     if len(experiments) == 1:
         ax.set_title(f"Attack Success Rate — {experiments[0]}")
     else:
         ax.set_title("Attack Success Rate by Experiment")
+
+    fig.text(
+        0.02,
+        0.02,
+        "Bars are weighted by total trials per experiment.",
+        ha="left",
+        va="bottom",
+        fontsize=8,
+        color="0.3",
+    )
 
     ax.set_xticks(list(positions))
     ax.set_xticklabels(
@@ -119,10 +176,12 @@ def main(argv: Optional[List[str]] = None) -> int:
         raise SystemExit("results/summary.csv not found; run `make report` first")
 
     rows = load_rows(CSV)
-    if not rows:
+    aggregates = weighted_asr_by_exp(rows)
+    if not aggregates:
         raise SystemExit("No usable rows in results/summary.csv")
 
-    experiments, means = aggregate_means(rows)
+    experiments = sorted(aggregates.keys())
+    means = [aggregates[exp] for exp in experiments]
     plot_summary(experiments, means)
     return 0
 


### PR DESCRIPTION
## Summary
- compute trial-weighted ASR per experiment so grouped bars reflect total successes divided by total trials
- annotate the plot with the new weighting (axis label and footnote) and document the behaviour in the README
- regenerate the demo summary.svg with the updated computation

## Testing
- make report
- make test *(fails: summary.csv schema mismatch in existing repository)*
- .venv/bin/python -m pytest tests/test_plot_results.py -q


------
https://chatgpt.com/codex/tasks/task_e_68c9a5b618408329ba7f459d7a0f9343