### PR TITLE
Skip unusable summary rows when weighting ASR

### DIFF
--- a/scripts/plot_results.py
+++ b/scripts/plot_results.py
@@ -103,6 +103,9 @@ def weighted_asr_by_exp(rows: Iterable[SummaryRow]) -> Dict[str, float]:
         if trials is None:
             continue
 
+        if row.successes is None and row.asr is None:
+            continue
+
         totals_trials[exp] += float(trials)
 
         if row.successes is not None:


### PR DESCRIPTION
## Summary
- compute trial-weighted ASR per experiment so grouped bars reflect total successes divided by total trials
- annotate the plot with the new weighting (axis label and footnote) and document the behaviour in the README
- regenerate the demo summary.svg with the updated computation
- skip rows without usable successes or ASR when aggregating so incomplete entries do not bias results

## Testing
- python -m pytest tests/test_plot_results.py -q

------
https://chatgpt.com/codex/tasks/task_e_68c9aab1934883299715490dc1ba55fd