### PR TITLE
Align tests with trial-weighted results schema

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,6 +60,11 @@ test: install demo
 	@test -f results/summary.svg || (echo "missing results/summary.svg" && exit 1)
 	@find results -type f -name '*seed*.jsonl' -print -quit | grep -q . || (echo "no per-seed jsonl files found under results/" && exit 1)
 	@echo "✅ Results schema & artifacts look good."
+	@if [ -x "$(PY)" ]; then \
+	"$(PY)" -m pytest -q; \
+	else \
+	pytest -q; \
+	fi
 
 check-schema: venv
 	$(PY) scripts/check_schema.py

--- a/tests/test_aggregate.py
+++ b/tests/test_aggregate.py
@@ -6,18 +6,17 @@ import pandas as pd
 
 
 EXPECTED_COLUMNS = [
-    "timestamp",
-    "run_id",
-    "git_sha",
-    "repo_dirty",
+    "exp_id",
     "exp",
-    "seed",
+    "config",
+    "cfg_hash",
     "mode",
+    "seeds",
     "trials",
     "successes",
     "asr",
-    "py_version",
-    "path",
+    "git_commit",
+    "run_at",
 ]
 
 
@@ -45,15 +44,18 @@ def test_aggregate_generates_summary():
     asr_values = pd.to_numeric(df["asr"], errors="coerce")
     trials = pd.to_numeric(df["trials"], errors="coerce")
     successes = pd.to_numeric(df["successes"], errors="coerce")
-    repo_dirty = df["repo_dirty"].astype(str).str.lower()
-    run_ids = df["run_id"].astype(str)
 
     assert asr_values.between(0.0, 1.0).all()
     assert (trials >= successes).all()
     assert (trials >= 0).all()
     assert (successes >= 0).all()
-    assert repo_dirty.isin(["true", "false"]).all()
-    assert run_ids.str.len().gt(0).all()
+
+    assert df["exp_id"].astype(str).str.len().gt(0).all()
+    assert df["exp"].astype(str).str.len().gt(0).all()
+    assert df["config"].astype(str).str.len().gt(0).all()
+    assert df["cfg_hash"].astype(str).str.len().gt(0).all()
+    assert df["mode"].astype(str).str.len().gt(0).all()
+    assert df["run_at"].astype(str).str.len().gt(0).all()
 
     readme = Path("README.md").read_text(encoding="utf-8")
     assert "<!-- RESULTS:BEGIN -->" in readme

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -1,11 +1,13 @@
 import csv
+import json
 import subprocess
 import sys
 from pathlib import Path
 
+import pytest
 import yaml
 
-from exp import load_config, make_exp_id
+from exp import load_config
 
 
 def test_results_paths(tmp_path):
@@ -30,14 +32,27 @@ def test_results_paths(tmp_path):
     assert "JSONL=" in proc.stdout
 
     normalized_cfg = load_config(temp_config)
-    exp_id = make_exp_id(normalized_cfg)
 
-    results_dir = Path("results") / f"{normalized_cfg['exp']}_{exp_id}"
-    jsonl_path = results_dir / f"seed{seed}.jsonl"
+    results_dir = Path("results") / str(normalized_cfg["exp"])
+    jsonl_path = results_dir / f"{normalized_cfg['exp']}_seed{seed}.jsonl"
     summary_path = Path("results") / "summary.csv"
 
     assert jsonl_path.exists()
     assert summary_path.exists()
+
+    header_event = None
+    summary_event = None
+    with jsonl_path.open("r", encoding="utf-8") as handle:
+        for line in handle:
+            payload = json.loads(line)
+            if header_event is None and payload.get("event") == "header":
+                header_event = payload
+            if payload.get("event") == "summary":
+                summary_event = payload
+    assert header_event is not None, "header event missing from JSONL"
+    assert summary_event is not None, "summary event missing from JSONL"
+
+    subprocess.check_call([sys.executable, "scripts/aggregate_results.py"])
 
     with summary_path.open("r", encoding="utf-8", newline="") as handle:
         reader = csv.DictReader(handle)
@@ -46,8 +61,24 @@ def test_results_paths(tmp_path):
     matching_rows = [
         row
         for row in rows
-        if row.get("exp") == normalized_cfg["exp"]
-        and row.get("seed") == str(seed)
-        and row.get("path") == jsonl_path.as_posix()
+        if row.get("config") == temp_config.as_posix()
     ]
     assert matching_rows, "Summary row for seed not found"
+
+    summary_row = matching_rows[-1]
+    assert summary_row.get("exp") == normalized_cfg["exp"]
+    assert summary_row.get("exp_id")
+    assert str(seed) in (summary_row.get("seeds") or "")
+    assert summary_row.get("mode") == header_event.get("mode")
+
+    trials_csv = int(summary_row.get("trials", 0))
+    successes_csv = int(summary_row.get("successes", 0))
+    asr_csv = float(summary_row.get("asr", 0.0))
+
+    trials_summary = int(summary_event.get("trials", 0))
+    successes_summary = int(summary_event.get("successes", 0))
+    asr_summary = float(summary_event.get("asr", 0.0))
+
+    assert trials_csv == trials_summary
+    assert successes_csv == successes_summary
+    assert asr_csv == pytest.approx(asr_summary)

--- a/tests/test_plot_results.py
+++ b/tests/test_plot_results.py
@@ -1,10 +1,144 @@
 from __future__ import annotations
 
+import csv
+import importlib.util
 import subprocess
 import sys
+from collections import defaultdict
 from pathlib import Path
+from typing import Dict, Iterable, List
+from xml.etree import ElementTree as ET
 
 import pytest
+
+# NOTE: The summary plot reports trial-weighted micro-average ASR values.
+
+
+def _parse_optional_float(value: object | None) -> float | None:
+    if value is None:
+        return None
+    if isinstance(value, str):
+        text = value.strip()
+        if not text:
+            return None
+        value = text
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _load_fixture_rows(csv_path: Path) -> List[Dict[str, float | str | None]]:
+    """Load rows using a case-insensitive header map."""
+
+    rows: List[Dict[str, float | str | None]] = []
+    with csv_path.open("r", encoding="utf-8", newline="") as handle:
+        reader = csv.DictReader(handle)
+        if reader.fieldnames is None:
+            return rows
+        for raw in reader:
+            if not raw:
+                continue
+            normalised: Dict[str, object | None] = {}
+            for key, value in raw.items():
+                if key is None:
+                    continue
+                normalised[key.strip().lower()] = value
+
+            exp = str(normalised.get("exp", "") or "").strip()
+            if not exp:
+                exp = "<unknown>"
+
+            asr_source = normalised.get("asr")
+            if asr_source is None:
+                asr_source = normalised.get("attack_success_rate")
+
+            rows.append(
+                {
+                    "exp": exp,
+                    "trials": _parse_optional_float(normalised.get("trials")),
+                    "successes": _parse_optional_float(normalised.get("successes")),
+                    "asr": _parse_optional_float(asr_source),
+                }
+            )
+    return rows
+
+
+def _trial_weighted_means(rows: Iterable[Dict[str, float | str | None]]) -> Dict[str, float]:
+    """Compute trial-weighted micro-averages.
+
+    The trials column acts as the weight, ensuring the resulting ASR is the
+    micro-average of successes divided by trials. When successes are missing we
+    fall back to the weighted ASR values (``asr * trials``).
+    """
+
+    totals_trials: Dict[str, float] = defaultdict(float)
+    totals_successes: Dict[str, float] = defaultdict(float)
+    fallback_totals: Dict[str, float] = defaultdict(float)
+    has_explicit_successes: Dict[str, bool] = defaultdict(bool)
+
+    for row in rows:
+        exp = str(row.get("exp") or "")
+        trials = row.get("trials")
+        if trials is None:
+            continue
+
+        trials_value = float(trials)
+        if trials_value <= 0:
+            continue
+
+        totals_trials[exp] += trials_value
+
+        successes_value = row.get("successes")
+        if successes_value is not None:
+            totals_successes[exp] += float(successes_value)
+            has_explicit_successes[exp] = True
+            continue
+
+        asr_value = row.get("asr")
+        if asr_value is not None:
+            fallback_totals[exp] += float(asr_value) * trials_value
+
+    aggregates: Dict[str, float] = {}
+    for exp, total_trials in totals_trials.items():
+        if total_trials <= 0:
+            continue
+        numerator = (
+            totals_successes[exp]
+            if has_explicit_successes[exp]
+            else fallback_totals[exp]
+        )
+        aggregates[exp] = numerator / total_trials
+    return aggregates
+
+
+def _load_plot_module():
+    spec = importlib.util.spec_from_file_location(
+        "plot_results_module", Path("scripts/plot_results.py")
+    )
+    if spec is None or spec.loader is None:  # pragma: no cover - defensive
+        raise RuntimeError("Unable to import plot_results module")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _count_bars(svg_path: Path) -> int:
+    tree = ET.parse(svg_path)
+    root = tree.getroot()
+    namespace = "{http://www.w3.org/2000/svg}"
+
+    bar_count = 0
+    for patch in root.findall(f".//{namespace}g"):
+        patch_id = patch.attrib.get("id", "")
+        if not patch_id.startswith("patch_"):
+            continue
+        for child in patch:
+            tag = child.tag.rsplit("}", 1)[-1]
+            if tag == "path" and "clip-path" in child.attrib:
+                bar_count += 1
+                break
+    return bar_count
 
 
 def test_plot_results_smoke():
@@ -13,6 +147,11 @@ def test_plot_results_smoke():
     summary_path = Path("results/summary.csv")
     if not summary_path.exists():
         pytest.skip("summary.csv missing; skipping plot smoke test")
+
+    fixture_rows = _load_fixture_rows(summary_path)
+    aggregates_from_fixture = _trial_weighted_means(fixture_rows)
+    if not aggregates_from_fixture:
+        pytest.skip("No usable rows in summary.csv; skipping plot smoke test")
 
     expected_files = [
         Path("results/summary.svg"),
@@ -27,6 +166,20 @@ def test_plot_results_smoke():
         [sys.executable, "scripts/plot_results.py", "--exp", "airline_escalating_v1"],
         check=True,
     )
+
+    plot_module = _load_plot_module()
+    module_rows = plot_module.load_rows(summary_path)
+    module_aggregates = plot_module.weighted_asr_by_exp(module_rows)
+
+    assert module_aggregates, "plot_results produced no aggregates"
+    assert module_aggregates.keys() == aggregates_from_fixture.keys()
+    for exp, expected_value in aggregates_from_fixture.items():
+        assert module_aggregates[exp] == pytest.approx(expected_value)
+
+    svg_path = Path("results/summary.svg")
+    svg_text = svg_path.read_text(encoding="utf-8")
+    assert "ASR (successes ÷ trials)" in svg_text
+    assert _count_bars(svg_path) == len(aggregates_from_fixture)
 
     for plot_file in expected_files:
         assert plot_file.exists(), f"{plot_file} was not created"

--- a/tests/test_summary_csv.py
+++ b/tests/test_summary_csv.py
@@ -2,18 +2,17 @@ import csv
 from pathlib import Path
 
 EXPECTED_COLUMNS = [
-    "timestamp",
-    "run_id",
-    "git_sha",
-    "repo_dirty",
+    "exp_id",
     "exp",
-    "seed",
+    "config",
+    "cfg_hash",
     "mode",
+    "seeds",
     "trials",
     "successes",
     "asr",
-    "py_version",
-    "path",
+    "git_commit",
+    "run_at",
 ]
 
 
@@ -24,22 +23,37 @@ def test_summary_csv_present_and_valid():
     with summary_path.open("r", encoding="utf-8", newline="") as handle:
         reader = csv.DictReader(handle)
         assert reader.fieldnames is not None, "summary.csv missing header"
-        assert (
-            reader.fieldnames == EXPECTED_COLUMNS
-        ), f"Unexpected header order: {reader.fieldnames}"
+        header = [column.strip() for column in reader.fieldnames]
+        assert header == EXPECTED_COLUMNS, f"Unexpected header order: {header}"
 
+        valid_rows = 0
         for row in reader:
-            assert row.get("trials"), "trials value missing"
-            assert row.get("successes"), "successes value missing"
-            assert row.get("asr"), "asr value missing"
-            assert row.get("run_id"), "run_id value missing"
-            assert row.get("repo_dirty") in {"true", "false"}, "repo_dirty must be true/false"
+            if not row.get("exp") or not row.get("exp_id"):
+                continue
 
-            trials = int(row["trials"])
-            successes = int(row["successes"])
-            asr = float(row["asr"])
+            trials_raw = row.get("trials")
+            successes_raw = row.get("successes")
+            asr_raw = row.get("asr")
+
+            assert row.get("config"), "config value missing"
+            assert row.get("cfg_hash"), "cfg_hash value missing"
+            assert row.get("mode"), "mode value missing"
+            assert row.get("git_commit") is not None, "git_commit column missing"
+            assert row.get("run_at"), "run_at value missing"
+
+            assert trials_raw, "trials value missing"
+            assert successes_raw is not None, "successes value missing"
+            assert asr_raw, "asr value missing"
+
+            trials = int(trials_raw)
+            successes = int(successes_raw)
+            asr = float(asr_raw)
 
             assert trials >= 0, "trials must be non-negative"
             assert successes >= 0, "successes must be non-negative"
             assert trials >= successes, "successes cannot exceed trials"
             assert 0.0 <= asr <= 1.0, "asr must be between 0 and 1"
+
+            valid_rows += 1
+
+        assert valid_rows > 0, "No valid rows found in summary.csv"


### PR DESCRIPTION
## Summary
- update the plot smoke test to parse the new summary schema, verify trial-weighted micro-averages, and assert plot contents
- refresh the summary CSV, aggregate, and results-path tests to expect the new columns and aggregated metadata
- ensure `make test` runs the pytest suite via the Makefile

## Testing
- make test

------
https://chatgpt.com/codex/tasks/task_e_68c9aafb423483298caa213c4194022f