### PR TITLE
Add timestamped results runs and publish latest summaries

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -45,16 +45,20 @@ jobs:
           python -m pip install -U pip
           if [ -f requirements-ci.txt ]; then pip install -r requirements-ci.txt; fi
 
+      - name: Select run id
+        run: echo "RUN_ID=$(date -u +'%Y%m%d-%H%M%S')" >> $GITHUB_ENV
+
       - name: Bootstrap & run SHIM sweep via Makefile
         env:
           EXP: airline_escalating_v1
           TRIALS: '5'
           SEEDS: '41,42,43'
           MODE: SHIM
+          RUN_ID: ${{ env.RUN_ID }}
         run: |
           make install
-          make xsweep EXP="$EXP" TRIALS="$TRIALS" SEEDS="$SEEDS" MODE="$MODE"
-          make report
+          make xsweep EXP="$EXP" TRIALS="$TRIALS" SEEDS="$SEEDS" MODE="$MODE" RUN_ID="$RUN_ID"
+          make report RUN_ID="$RUN_ID"
 
       - name: Upload results
         if: always()
@@ -62,8 +66,7 @@ jobs:
         with:
           name: results
           path: |
-            results/**
+            results/${{ env.RUN_ID }}/**
             results/summary.csv
-            results/summary.png
             results/summary.svg
             results/summary.md

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This repository is a scaffold for the TAUBench Airline example in DoomArena.
 - Run offline: `make install && make run`
 - Tests: `make test` (runs demo + results validation)
 - Schema check: `make check-schema`
-- Results (JSONL) will be written under `results/`.
+- Results (JSONL) will be written under timestamped run folders such as `results/20240101-120000/` (UTC).
 
 ### Quickstart (experiments)
 
@@ -40,14 +40,16 @@ make demo
 open results/summary.svg   # or download from CI artifacts on the PR
 ```
 
-This runs airline_escalating_v1 and airline_static_v1 in SHIM mode with two seeds × three trials, aggregates to results/summary.csv, and renders results/summary.svg with one bar per experiment.
+This runs airline_escalating_v1 and airline_static_v1 in SHIM mode with two seeds × three trials. The per-seed logs land in `results/<RUN_ID>/…` (UTC timestamp), the run-specific summaries are written to `results/<RUN_ID>/summary.*`, and `make report` publishes copies to `results/summary.*` for quick inspection.
 
 ### Run an experiment
 
 ```bash
 make xsweep CONFIG=configs/airline_escalating_v1/exp.yaml
+make report
 head -5 results/summary.csv
-ls -R results/*
+RUN_ID=$(make latest)
+ls results/$RUN_ID
 ```
 
 ### Swapping to real DoomArena classes
@@ -63,7 +65,7 @@ This repo currently uses thin adapters to mirror DoomArena concepts:
 
 ## Results
 
-`make report` also writes `results/summary.md` (a readable notes file) and the CI run uploads it as an artifact.
+Each sweep writes JSONL files under `results/<RUN_ID>/` where `<RUN_ID>` is a UTC timestamp in the form `YYYYmmdd-HHMMSS`. Running `make report` aggregates that directory into `results/<RUN_ID>/summary.csv`, `summary.svg`, and `summary.md`, then publishes copies to `results/summary.*` for backwards compatibility. The published run id is written to `results/LATEST` and can be echoed with `make latest`. CI artifacts now include both the timestamped run folder and the published summaries.
 
 ### Results plot
 
@@ -75,12 +77,25 @@ with more trials carry proportionally more weight in the chart.
 
 ![Results summary](results/summary.svg)
 
-| exp | seeds | mode | ASR | trials | successes | git | run_at |
-| --- | --- | --- | --- | --- | --- | --- | --- |
-| airline_static_v1 | 12,11 | SHIM | 0.33 (1/3) | 3 | 1 | 235eb543 | 2025-09-16T16:54:51.365106+00:00 |
-| airline_static_v1 | 11,12 | SHIM | 0.33 (1/3) | 3 | 1 | 235eb543 | 2025-09-16T16:54:51.193991+00:00 |
-| airline_escalating_v1 | 12 | SHIM | 0.33 (1/3) | 3 | 1 | 235eb543 | 2025-09-16T16:54:50.856852+00:00 |
-| airline_escalating_v1 | 11 | SHIM | 0.33 (1/3) | 3 | 1 | 235eb543 | 2025-09-16T16:54:50.677487+00:00 |
+# Experiment summary — 2025-09-16T19:31:21+00:00
+
+- Experiments: 2
+- Total trials: 12
+- Total successes: 4
+- Micro-average ASR: 33.3%
+
+The bar chart below shows trial-weighted attack success rates per experiment (micro-averaged by trials).
+
+![ASR summary](summary.svg)
+
+| Experiment | Trials | Successes | ASR (%) |
+| --- | --- | --- | --- |
+| airline_escalating_v1 | 6 | 2 | 33.3% |
+| airline_static_v1 | 6 | 2 | 33.3% |
+
+---
+
+*How this was generated:* Run `make xsweep …` followed by `make report` to reproduce these notes.
 
 <!-- RESULTS:END -->
 
@@ -99,8 +114,8 @@ Use `make check-schema` to verify the file matches the expected schema.
 
 |rank|exp_id|ASR|mode|trials|seeds|commit|run_at|
 |---|---|---|---|---|---|---|---|
-|1|airline_static_v1:93da93d2|0.333|SHIM|3|12,11|235eb54|2025-09-16T16:54:51.365106+00:00|
-|2|airline_static_v1:93da93d2|0.333|SHIM|3|11,12|235eb54|2025-09-16T16:54:51.193991+00:00|
-|3|airline_escalating_v1:3762657d|0.333|SHIM|3|12|235eb54|2025-09-16T16:54:50.856852+00:00|
-|4|airline_escalating_v1:3762657d|0.333|SHIM|3|11|235eb54|2025-09-16T16:54:50.677487+00:00|
+|1|airline_static_v1:93da93d2|0.333|SHIM|3|12,11|6048d3b|2025-09-16T19:31:19.911401+00:00|
+|2|airline_static_v1:93da93d2|0.333|SHIM|3|11,12|6048d3b|2025-09-16T19:31:19.676163+00:00|
+|3|airline_escalating_v1:3762657d|0.333|SHIM|3|12|6048d3b|2025-09-16T19:31:19.265401+00:00|
+|4|airline_escalating_v1:3762657d|0.333|SHIM|3|11|6048d3b|2025-09-16T19:31:19.016015+00:00|
 <!-- TOPN:END -->

--- a/scripts/aggregate_results.py
+++ b/scripts/aggregate_results.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import csv
 import json
+import argparse
 from pathlib import Path
 from typing import Any, Dict, Iterable, List, Tuple
 
@@ -262,8 +263,19 @@ def write_summary_md(base_dir: Path, rows: List[Dict[str, str]]) -> None:
     md_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
 
 
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Aggregate DoomArena run outputs")
+    parser.add_argument(
+        "--outdir",
+        default="results",
+        help="Directory to scan for jsonl files and write summaries",
+    )
+    return parser.parse_args()
+
+
 def main() -> None:
-    base_dir = Path("results")
+    args = parse_args()
+    base_dir = Path(args.outdir).expanduser()
     base_dir.mkdir(parents=True, exist_ok=True)
     summary_path = base_dir / "summary.csv"
 

--- a/scripts/auto_notes.py
+++ b/scripts/auto_notes.py
@@ -11,12 +11,9 @@ from __future__ import annotations
 
 import csv
 from datetime import datetime, timezone
+import argparse
 from pathlib import Path
 from typing import Dict, Iterable, List, Optional
-
-SUMMARY_CSV = Path("results/summary.csv")
-SUMMARY_MD = Path("results/summary.md")
-
 
 def _parse_int(value: Optional[str]) -> Optional[int]:
     if value is None:
@@ -214,12 +211,27 @@ def render_markdown(experiments: List[ExperimentRow]) -> str:
     return "\n".join(lines)
 
 
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Generate Markdown notes for a run")
+    parser.add_argument(
+        "--outdir",
+        default="results",
+        help="Directory containing summary.csv and where summary.md should be written",
+    )
+    return parser.parse_args()
+
+
 def main() -> None:
-    rows = load_summary(SUMMARY_CSV)
+    args = parse_args()
+    outdir = Path(args.outdir).expanduser()
+    summary_csv = outdir / "summary.csv"
+    summary_md = outdir / "summary.md"
+
+    rows = load_summary(summary_csv)
     experiments = aggregate(rows)
     markdown = render_markdown(experiments)
-    SUMMARY_MD.parent.mkdir(parents=True, exist_ok=True)
-    SUMMARY_MD.write_text(markdown, encoding="utf-8")
+    summary_md.parent.mkdir(parents=True, exist_ok=True)
+    summary_md.write_text(markdown, encoding="utf-8")
 
 
 if __name__ == "__main__":

--- a/scripts/run_batch.py
+++ b/scripts/run_batch.py
@@ -256,8 +256,9 @@ def main() -> None:
     except ValueError as exc:
         raise SystemExit(str(exc)) from exc
 
-    outdir = Path(args.outdir)
-    summary_path = Path("results") / "summary.csv"
+    outdir = Path(args.outdir).expanduser()
+    outdir.mkdir(parents=True, exist_ok=True)
+    summary_path = outdir / "summary.csv"
     existing_rows = read_existing_summary(summary_path)
     commit = git_sha()
     run_id = generate_run_id()

--- a/scripts/run_experiment.py
+++ b/scripts/run_experiment.py
@@ -30,6 +30,11 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--mode", help="Override config mode (e.g. SHIM or REAL)", default=None)
     parser.add_argument("--trials", type=int, help="Override config trials count", default=None)
     parser.add_argument("--exp", help="Override config experiment name", default=None)
+    parser.add_argument(
+        "--outdir",
+        default="results",
+        help="Directory where experiment artifacts should be written",
+    )
     return parser.parse_args()
 def _prepare_attack(cfg: Dict[str, Any]) -> tuple[EscalatingDialogueAttackAdapter, int]:
     suffixes = cfg.get("suffixes") or []
@@ -136,7 +141,8 @@ def main() -> None:
     mode = str(cfg.get("mode", "SHIM")).upper()
     trials = int(cfg.get("trials", 0))
 
-    results_dir = Path("results") / str(exp)
+    outdir = Path(args.outdir).expanduser()
+    results_dir = outdir / str(exp)
     jsonl_path = results_dir / f"{exp}_seed{seed}.jsonl"
 
     jsonl_path.parent.mkdir(parents=True, exist_ok=True)

--- a/scripts/xsweep.py
+++ b/scripts/xsweep.py
@@ -39,6 +39,11 @@ def parse_args() -> argparse.Namespace:
         default=None,
         help="Experiment name override passed to run_experiment.py",
     )
+    parser.add_argument(
+        "--outdir",
+        default="results",
+        help="Directory where per-seed outputs should be written",
+    )
     return parser.parse_args()
 
 
@@ -85,6 +90,9 @@ def main() -> int:
         print("xsweep: no seeds in config; nothing to run")
         return 0
 
+    outdir = Path(args.outdir).expanduser()
+    outdir.mkdir(parents=True, exist_ok=True)
+
     rc = 0
     for seed in seeds:
         cmd = [
@@ -95,6 +103,7 @@ def main() -> int:
             "--seed",
             str(seed),
         ]
+        cmd.extend(["--outdir", outdir.as_posix()])
         if args.trials is not None:
             cmd.extend(["--trials", str(int(args.trials))])
         if args.mode:

--- a/scripts/xsweep_all.py
+++ b/scripts/xsweep_all.py
@@ -14,6 +14,7 @@ def main():
     p.add_argument("--trials", type=int, default=int(os.getenv("TRIALS", "5")))
     p.add_argument("--mode", default=os.getenv("MODE", "SHIM"))
     p.add_argument("--exp", default=None, help="limit to a single exp name (dir name under configs/)")
+    p.add_argument("--outdir", default=os.getenv("RUN_DIR", "results"), help="Output directory for run artifacts")
     args = p.parse_args()
 
     cfgs = sorted(glob.glob(args.glob))
@@ -22,6 +23,9 @@ def main():
 
     xsweep = Path("scripts/xsweep.py")
     rc = 0
+    outdir = Path(args.outdir).expanduser()
+    outdir.mkdir(parents=True, exist_ok=True)
+
     for cfg in cfgs:
         exp = Path(cfg).parent.name
         if xsweep.exists():
@@ -32,6 +36,7 @@ def main():
                 "--trials", str(args.trials),
                 "--mode", args.mode,
                 "--exp", exp,
+                "--outdir", outdir.as_posix(),
             ]
             rc |= run(cmd)
         else:
@@ -44,6 +49,7 @@ def main():
                     "--trials", str(args.trials),
                     "--mode", args.mode,
                     "--exp", exp,
+                    "--outdir", outdir.as_posix(),
                 ]
                 rc |= run(cmd)
     sys.exit(rc)


### PR DESCRIPTION
## Summary
- add RUN_ID handling in the Makefile, persist per-invocation run directories, and publish the latest summaries to the legacy locations
- update xsweep, run_experiment, run_batch, aggregate_results, plot_results, auto_notes, and xsweep_all to accept an --outdir and operate within the timestamped run folder
- refresh README guidance and the smoke workflow to surface the run id, document the new layout, and upload both the run folder and published artifacts in CI

## Testing
- make demo

------
https://chatgpt.com/codex/tasks/task_e_68c9b5cada5c8329bb776aeb6db6adce