### PR TITLE
Add HTML report generation and latest artifact comment updates

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -72,3 +72,15 @@ jobs:
             results/summary.md
             results/run.json
             results/LATEST/run.json
+      - name: Upload latest artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: latest-artifacts
+          path: |
+            results/LATEST/summary.csv
+            results/LATEST/summary.svg
+            results/LATEST/run.json
+            results/LATEST/index.html
+          if-no-files-found: error
+          retention-days: 7

--- a/Makefile
+++ b/Makefile
@@ -153,6 +153,11 @@ report: aggregate plot notes latest
 	cp -f "$(RUN_DIR)/summary.md" $(RESULTS_DIR)/summary.md
 	cp -f "$(RUN_DIR)/notes.md" $(RESULTS_DIR)/notes.md 2>/dev/null || true
 	cp -f "$(RUN_DIR)/run.json" $(RESULTS_DIR)/run.json 2>/dev/null || true
+	# Generate per-run HTML report + mirror to LATEST
+	python tools/mk_report.py "$(RUN_DIR)"
+	if [ -e "$(RESULTS_DIR)/LATEST" ] || [ -L "$(RESULTS_DIR)/LATEST" ] || [ -f "$(RESULTS_DIR)/LATEST.path" ]; then \
+		python tools/mk_report.py "$(RESULTS_DIR)/LATEST"; \
+	fi
 	rm -f $(RUN_CURRENT)
 	if [ -x "$(PY)" ]; then \
 		"$(PY)" scripts/update_readme_results.py; \

--- a/tools/mk_report.py
+++ b/tools/mk_report.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""Build a tiny, dependency-free HTML report for a results directory."""
+from __future__ import annotations
+import csv, json, html, sys
+from pathlib import Path
+
+def read_rows(csv_path: Path):
+    rows = []
+    if not csv_path.exists():
+        return rows
+    with csv_path.open(newline="") as f:
+        rdr = csv.DictReader(f)
+        for r in rdr:
+            rows.append({(k or "").strip(): (v or "") for k, v in r.items()})
+    return rows
+
+def load_run_meta(run_dir: Path):
+    data = {}
+    p = run_dir / "run.json"
+    if p.exists():
+        try:
+            data = json.loads(p.read_text(encoding="utf-8"))
+        except Exception:
+            data = {}
+    return data
+
+def build_table(rows):
+    if not rows:
+        return "<p><em>No rows in summary.csv</em></p>"
+    hdrs = list(rows[0].keys())
+    thead = "".join(f"<th>{html.escape(h)}</th>" for h in hdrs)
+    body = []
+    for r in rows:
+        tds = "".join(f"<td>{html.escape(str(r.get(h,'')))}</td>" for h in hdrs)
+        body.append(f"<tr>{tds}</tr>")
+    return f"<table><thead><tr>{thead}</tr></thead><tbody>{''.join(body)}</tbody></table>"
+
+
+def resolve_run_dir(path: Path) -> Path:
+    """Resolve symlinks and fallback pointer files like results/LATEST.path."""
+    resolved = path.resolve(strict=False)
+    if resolved.exists():
+        return resolved
+    pointer = path.parent / f"{path.name}.path"
+    if pointer.exists():
+        target = Path(pointer.read_text(encoding="utf-8").strip())
+        if target.exists():
+            try:
+                return target.resolve()
+            except Exception:
+                return target
+    return resolved
+
+
+def write_report(run_dir: Path):
+    run_dir = resolve_run_dir(run_dir)
+    rows = read_rows(run_dir / "summary.csv")
+    table_html = build_table(rows)
+    meta = load_run_meta(run_dir)
+    schema = html.escape(str(meta.get("summary_schema", "")))
+    results_schema = html.escape(str(meta.get("results_schema", "")))
+    run_id = html.escape(run_dir.name)
+    svg_rel = "summary.svg"
+    svg_tag = (
+        f"<object type='image/svg+xml' data='{svg_rel}' width='100%'></object>"
+        if (run_dir / svg_rel).exists()
+        else "<p><em>summary.svg not found</em></p>"
+    )
+    meta_rows = []
+    if run_id: meta_rows.append(f"<div><strong>Run:</strong> {run_id}</div>")
+    if schema: meta_rows.append(f"<div><strong>summary_schema:</strong> {schema}</div>")
+    if results_schema: meta_rows.append(f"<div><strong>results_schema:</strong> {results_schema}</div>")
+    meta_html = "<div class='meta'>" + " · ".join(meta_rows) + "</div>"
+
+    html_doc = f"""<!doctype html>
+    <meta charset="utf-8">
+    <title>DoomArena-Lab Run Report — {run_id}</title>
+    <style>
+      body{{font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; margin:24px;}}
+      h1,h2{{margin:0 0 12px}}
+      .meta{{color:#666; font-size:13px; margin:8px 0 16px}}
+      table{{border-collapse:collapse; margin-top:8px; width:100%; max-width:980px}}
+      th,td{{border:1px solid #ddd; padding:6px 8px; font-size:14px}}
+      th{{background:#f6f6f6; text-align:left}}
+      code{{background:#f2f2f2; padding:2px 4px; border-radius:4px}}
+    </style>
+    <h1>DoomArena-Lab Run Report</h1>
+    {meta_html}
+    <h2>Summary chart</h2>
+    {svg_tag}
+    <h2>Summary table</h2>
+    {table_html}
+    <p class="meta">Files: <code>summary.csv</code> · <code>summary.svg</code> · <code>run.json</code></p>
+    """
+    output = run_dir / "index.html"
+    output.write_text(html_doc, encoding="utf-8")
+    print(f"Wrote {output}")
+
+def main(argv):
+    if len(argv) < 2:
+        print("usage: mk_report.py <RUN_DIR>")
+        return 2
+    write_report(Path(argv[1]))
+    return 0
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/tools/pr_comment_latest.py
+++ b/tools/pr_comment_latest.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+"""Build PR comment markdown summarizing the latest smoke results."""
+from __future__ import annotations
+
+import csv
+import json
+import sys
+from pathlib import Path
+
+
+def read_rows(csv_path: Path) -> list[dict[str, str]]:
+    if not csv_path.exists():
+        return []
+    with csv_path.open(newline="", encoding="utf-8") as f:
+        reader = csv.DictReader(f)
+        return [{k or "": v or "" for k, v in row.items()} for row in reader]
+
+
+def rows_to_markdown(rows: list[dict[str, str]], limit: int = 10) -> str:
+    if not rows:
+        return "_No rows in `summary.csv`_"
+    headers = list(rows[0].keys())
+    lines = []
+    header_row = "| " + " | ".join(headers) + " |"
+    separator = "| " + " | ".join(["---"] * len(headers)) + " |"
+    lines.append(header_row)
+    lines.append(separator)
+    for row in rows[:limit]:
+        line = "| " + " | ".join(str(row.get(h, "")) for h in headers) + " |"
+        lines.append(line)
+    remaining = len(rows) - limit
+    if remaining > 0:
+        extras = ["…"] * len(headers)
+        if len(headers) > 1:
+            extras[1] = f"({remaining} more rows)"
+        extras_line = "| " + " | ".join(extras) + " |"
+        lines.append(extras_line)
+    return "\n".join(lines)
+
+
+def load_schema(results_dir: Path) -> str:
+    run_json = results_dir / "run.json"
+    if not run_json.exists():
+        return ""
+    try:
+        data = json.loads(run_json.read_text(encoding="utf-8"))
+    except Exception:
+        return ""
+    return str(data.get("summary_schema", ""))
+
+
+def main(argv: list[str]) -> int:
+    results = Path(argv[1]) if len(argv) > 1 else Path("results/LATEST")
+    rows = read_rows(results / "summary.csv")
+    md_table = rows_to_markdown(rows)
+    schema = load_schema(results)
+
+    lines = [
+        "### DoomArena-Lab PR smoke results",
+        "",
+        f"Schema: `{schema or 'n/a'}`",
+        "",
+        "**Latest artifacts**: `results/LATEST/` (CSV/SVG/HTML)",
+        "",
+        md_table,
+        "",
+        "_Open_ `results/LATEST/index.html` and `summary.svg` from **Artifacts** in this run.",
+    ]
+    body = "\n".join(lines).strip()
+
+    print(body)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))


### PR DESCRIPTION
## Summary
- add a lightweight `tools/mk_report.py` helper that renders run metadata, SVG, and table into an `index.html` report (supports LATEST pointer files)
- update the `report` make target to build per-run and latest HTML reports and publish the new artifact from the smoke workflow
- add `tools/pr_comment_latest.py` to surface the schema and HTML link in the PR smoke comment

## Testing
- python -m py_compile tools/mk_report.py tools/pr_comment_latest.py

------
https://chatgpt.com/codex/tasks/task_e_68cd43670e9c8329a462210f08e060b7