### PR TITLE
Fix latest/open-artifacts targets for verifier

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -187,9 +187,12 @@ ci: install
 	$(MAKE) report RUN_ID=$(RUN_ID)
 
 .PHONY: latest
+# Refresh results/LATEST to point at newest valid run (CSV+SVG)
 latest:
 	@$(PYTHON) tools/latest_run.py $(RESULTS_DIR) $(LATEST_LINK) || true
 
 .PHONY: open-artifacts
-open-artifacts: latest
+# Open latest summary.svg and summary.csv (prints paths in CI)
+open-artifacts:
+	@$(MAKE) latest
 	@$(PYTHON) tools/open_artifacts.py


### PR DESCRIPTION
## Summary
- add standalone latest and open-artifacts targets in the Makefile so verifier sees bare labels
- keep documentation via preceding comments and invoke latest from open-artifacts recipe to preserve behavior

## Testing
- python tools/verify_latest_setup.py

------
https://chatgpt.com/codex/tasks/task_e_68cd6b65e5e48329a0394c6692a38651