### PR TITLE
Handle WARN statuses in strict threshold mode

### DIFF
--- a/tests/test_thresholds.py
+++ b/tests/test_thresholds.py
@@ -13,4 +13,19 @@ def test_evaluate_mixes_warn_and_fail():
     status = {r["exp"]: r["status"] for r in md_rows}
     assert status["a"] == "PASS"
     assert status["b"] == "FAIL"
+    assert worst == 2
+
+
+def test_evaluate_warn_for_min_trials_and_missing():
+    rows = [
+        {"exp": "c", "trials": "1", "successes": "0"},
+    ]
+    th = {
+        "c": {"min_trials": 3},
+        "d": {"min_trials": 1},
+    }
+    md_rows, worst = evaluate(rows, th)
+    status = {r["exp"]: r["status"] for r in md_rows}
+    assert status["c"] == "WARN"
+    assert status["d"] == "WARN"
     assert worst == 1


### PR DESCRIPTION
## Summary
- track PASS/WARN/FAIL severities when evaluating thresholds so that WARN rows are recorded as the worst outcome when present
- propagate WARN severities to strict mode exit handling and document the new behavior in the CLI help text
- extend the threshold tests to cover WARN-only scenarios and the updated severity scale

## Testing
- make test

------
https://chatgpt.com/codex/tasks/task_e_68cd6171d37483298a62117c9a4ca38a