### PR TITLE
CI: run demo via make demo

### DIFF
--- a/.github/workflows/run-demo.yml
+++ b/.github/workflows/run-demo.yml
@@ -31,9 +31,8 @@ jobs:
           MODE: ${{ inputs.mode }}
         run: |
           make demo TRIALS="${TRIALS}" SEEDS="${SEEDS}" MODE="${MODE}"
-      - name: Report + publish LATEST
+      - name: Publish LATEST
         run: |
-          make report
           make latest
       - name: Upload latest artifacts
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary
- run the demo workflow via `make demo` so both airline experiments share a RUN_ID

## Testing
- not run (workflow-only change)


------
https://chatgpt.com/codex/tasks/task_e_68cd9e92d2548329866860f6d444f5dd