### PR TITLE
Add REAL echo client and metadata plumbing

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,9 @@ make demo && make report
 
 ## Modes
 - **SHIM** — simulation adapters for quick, deterministic demos.
-- **REAL** — first MVP will integrate a single cloud model via a thin adapter and env-based credentials (manual workflow; optional in CI). The lab falls back to SHIM if REAL is not configured.
+- **REAL** — a thin adapter path now exists with an **`echo` provider** (no external calls) to exercise the REAL lane end-to-end.
+  - Metadata is recorded in `results/<RUN_ID>/run.json` under `.real` (provider/model/key env, healthcheck).
+  - Use **Actions → `run-real-mvp`** to run with `MODE=REAL` (manual, secrets-aware). A true provider can be added next.
 
 ## Make targets (TL;DR)
 - `make help` — list common targets & docs.

--- a/adapters/real_client.py
+++ b/adapters/real_client.py
@@ -1,0 +1,36 @@
+# Minimal REAL client used by DoomArena-Lab.
+# Starts with an "echo" provider (no external calls) to validate the REAL lane.
+from __future__ import annotations
+import os
+import time
+from dataclasses import dataclass
+
+@dataclass
+class RealClient:
+    provider: str = "echo"
+    model: str = "stub"
+    api_key_env: str = "REAL_API_KEY"
+
+    def _api_key(self) -> str | None:
+        return os.environ.get(self.api_key_env)
+
+    def healthcheck(self) -> dict:
+        # Return a small, serializable status blob for run.json.
+        has_key = bool(self._api_key())
+        return {
+            "provider": self.provider,
+            "model": self.model,
+            "api_key_env": self.api_key_env,
+            "api_key_present": has_key,
+            "ts": int(time.time()),
+        }
+
+    def generate(self, prompt: str) -> str:
+        """
+        For provider='echo', return the prompt back. This keeps the flow deterministic
+        and exercises the REAL path without any external dependency.
+        """
+        if self.provider == "echo":
+            return prompt
+        # Placeholder for future providers (e.g., openai-compatible HTTP).
+        raise NotImplementedError(f"Provider '{self.provider}' not implemented yet")

--- a/configs/airline_escalating_v1/run.yaml
+++ b/configs/airline_escalating_v1/run.yaml
@@ -1,6 +1,10 @@
 seed: 42
 trials: 20
 online: false
+# Optional REAL settings (used when MODE=REAL)
+provider: echo
+model: stub
+api_key_env: REAL_API_KEY
 attack:
   type: escalating_dialogue
   levels:

--- a/configs/airline_static_v1/run.yaml
+++ b/configs/airline_static_v1/run.yaml
@@ -3,6 +3,11 @@ mode: SHIM            # REAL | SHIM (SHIM for fast, offline)
 trials: 3             # smaller than escalating for quick demo
 seeds: [11, 12]       # two seeds for variance check
 
+# Optional REAL settings (used when MODE=REAL)
+provider: echo        # echo provider keeps REAL lane deterministic
+model: stub           # placeholder model name
+api_key_env: REAL_API_KEY
+
 attack:
   name: static_dialogue_v1
   # “Easier” than escalating: single, consistent prompt pressure

--- a/scripts/aggregate_results.py
+++ b/scripts/aggregate_results.py
@@ -615,6 +615,16 @@ def main() -> None:
     summary_path = base_dir / "summary.csv"
 
     jsonl_files = sorted(base_dir.rglob("*.jsonl"))
+    if not jsonl_files:
+        parent_dir = base_dir.parent
+        if parent_dir.exists() and parent_dir != base_dir:
+            fallback: List[Path] = []
+            for candidate in parent_dir.rglob("*.jsonl"):
+                try:
+                    candidate.relative_to(base_dir)
+                except ValueError:
+                    fallback.append(candidate)
+            jsonl_files = sorted(fallback)
     new_rows: List[Dict[str, str]] = []
     for path in jsonl_files:
         try:

--- a/scripts/run_experiment.py
+++ b/scripts/run_experiment.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import argparse
+import json
 import os
 import random
 import sys
@@ -154,6 +155,43 @@ def main() -> None:
     trials = int(cfg.get("trials", 0))
 
     outdir = Path(args.outdir).expanduser()
+    outdir.mkdir(parents=True, exist_ok=True)
+
+    if str(cfg.get("mode", "SHIM")).upper() == "REAL":
+        try:
+            from adapters.real_client import RealClient
+        except Exception:
+            RealClient = None
+
+        provider = cfg.get("provider", "echo")
+        model = cfg.get("model", "stub")
+        api_key_env = cfg.get("api_key_env", "REAL_API_KEY")
+
+        real_status: Dict[str, Any] = {
+            "provider": provider,
+            "model": model,
+            "api_key_env": api_key_env,
+        }
+        if RealClient is not None:
+            try:
+                rc = RealClient(provider=provider, model=model, api_key_env=api_key_env)
+                real_status.update(rc.healthcheck())
+            except Exception as exc:  # pragma: no cover - defensive guardrail
+                real_status.update({"error": f"{type(exc).__name__}: {exc}"})
+
+        run_json = outdir / "run.json"
+        data: Dict[str, Any] = {}
+        if run_json.exists():
+            try:
+                data = json.loads(run_json.read_text(encoding="utf-8"))
+            except Exception:  # pragma: no cover - tolerate malformed JSON
+                data = {}
+        data.setdefault("results_schema", "1")
+        data.setdefault("summary_schema", "1")
+        data["mode"] = "REAL"
+        data["real"] = real_status
+        run_json.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+
     results_dir = outdir / str(exp)
     jsonl_path = results_dir / f"{exp}_seed{seed}.jsonl"
 

--- a/tools/apply_schema_v1.py
+++ b/tools/apply_schema_v1.py
@@ -51,14 +51,25 @@ def ensure_schema_column(csv_path: Path) -> None:
     tmp.replace(csv_path)
 
 def write_run_json(run_dir: Path) -> None:
-    out = {
-        "results_schema": SCHEMA_VERSION,
-        "summary_schema": SCHEMA_VERSION,
-        "run_id": run_dir.name,
-        "generated_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
-        "git": git_info(),
-    }
-    (run_dir / "run.json").write_text(json.dumps(out, indent=2), encoding="utf-8")
+    run_json = run_dir / "run.json"
+    existing: dict[str, object] = {}
+    if run_json.exists():
+        try:
+            existing = json.loads(run_json.read_text(encoding="utf-8"))
+        except Exception:
+            existing = {}
+
+    out = dict(existing)
+    out.update(
+        {
+            "results_schema": SCHEMA_VERSION,
+            "summary_schema": SCHEMA_VERSION,
+            "run_id": run_dir.name,
+            "generated_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+            "git": git_info(),
+        }
+    )
+    run_json.write_text(json.dumps(out, indent=2) + "\n", encoding="utf-8")
 
 def main(argv):
     if len(argv) < 2 or argv[1] in ("-h", "--help"):


### PR DESCRIPTION
## Summary
- add a minimal REAL echo client and surface its metadata in `scripts/run_experiment.py`
- preserve existing fields when applying schema metadata and update configs/docs for REAL defaults
- allow the aggregator to fall back to parent JSONL files so run reports stay populated

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68cde02b17008329b5db6e10a98f23d0