### PR TITLE
Add journal entry for 2025-09-20

### DIFF
--- a/docs/journal/2025-09-20.md
+++ b/docs/journal/2025-09-20.md
@@ -1,0 +1,24 @@
+# 2025-09-20
+
+## What we did
+- **Provider probes**: Added `probe-provider` workflow and fixed model IDs + parsing so we can reliably ping Groq (OpenAI-compatible) and see `REPLY` + token **usage** in the Summary.
+- **Secrets hygiene**: Set up `GROQ_API_KEY` in GitHub Actions; documented where to configure **workflow permissions** and how secrets behave with forks.
+- **Run artifacts**: Cleaned `run-demo` artifacts; now publish a concise `latest-artifacts/` bundle and a per-run directory (`run-<RUN_ID>/`) with less redundancy.
+- **REAL groundwork**:
+  - Added a minimal **Groq client** and a **REAL MVP** runner writing timestamped `results/<RUN_ID>/` with `reply.txt`, `response.json`, `usage.json`, and `run.json`.
+  - Wired **telemetry** (latency, tokens) and **optional cost** hooks; surfaced in `summary.csv` and `index.html`.
+
+## Why this mattered
+- We now have a **clean, CI-safe path** to exercise a real LLM without needing local setup.
+- Artifacts are **deterministic** and **reviewable** (HTML + CSV), with cost/latency visibility—useful for governance and ROI conversations.
+- This sets the stage to plug a **real risky task** (τ-Bench) into the same pipeline.
+
+## Evidence / Example
+- `Actions → probe-provider` shows `REPLY: ...` and `USAGE: prompt=… completion=… total=…`.
+- `Actions → run-real-mvp` uploads `real-run-<RUN_ID>/` containing `reply.txt`, `usage.json`, and `run.json`.
+- Latest report (`results/index.html`) now includes **sum tokens**, **avg latency (ms)**, and **sum cost (USD)** when prices are provided via env.
+
+## Priorities (next)
+1. **REAL experiment (tau-bench risky task):** Wire a concrete τ-Bench security scenario end-to-end via Groq; emit per-trial JSONL; aggregate/plot/report.
+2. **Policy gates v1:** Add lightweight checks (PII/redaction, disallowed intents) enforced during REAL runs; record policy decisions in `run.json`.
+3. **Judge/criteria clarity:** Replace heuristic with an explicit judge (rule-based first; model-based later) for pass/fail definitions.


### PR DESCRIPTION
## Summary
- add a 2025-09-20 journal entry covering provider probes, secrets hygiene, REAL groundwork, and priorities

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68cfd8aa6718832996e21d9dbfcd5160