### PR TITLE
Fail on empty summary and add REAL run diagnostics

### DIFF
--- a/.github/workflows/run-real-mvp.yml
+++ b/.github/workflows/run-real-mvp.yml
@@ -66,6 +66,42 @@ jobs:
           test -s "results/${RUN_ID}/summary.svg"
           test -s "results/${RUN_ID}/index.html"
 
+      - name: Diagnose outputs (list RUN_DIR and preview CSV)
+        if: always()
+        run: |
+          RID="${RUN_ID:-}"
+          if [ -z "$RID" ] && [ -f results/.run_id ]; then
+            RID="$(cat results/.run_id)"
+          fi
+
+          if [ -n "$RID" ]; then
+            echo "RUN_ID=$RID"
+          else
+            echo "RUN_ID not available"
+          fi
+
+          echo
+
+          if [ -n "$RID" ] && [ -d "results/$RID" ]; then
+            echo "Tree of results/$RID (max depth 2):"
+            find "results/$RID" -maxdepth 2 -type f -print | sort || true
+
+            echo
+            echo "Summary CSV (first 10 lines):"
+            if [ -f "results/$RID/summary.csv" ]; then
+              head -n 10 "results/$RID/summary.csv" || true
+              echo
+              echo "Line count:"
+              wc -l "results/$RID/summary.csv" || true
+            else
+              echo "results/$RID/summary.csv not found"
+            fi
+          elif [ -n "$RID" ]; then
+            echo "Run directory results/$RID not found"
+          else
+            echo "Run directory could not be determined"
+          fi
+
       - name: Upload per-run artifacts
         if: always()
         uses: actions/upload-artifact@v4

--- a/scripts/aggregate_results.py
+++ b/scripts/aggregate_results.py
@@ -682,6 +682,7 @@ def main() -> None:
     summary_path = base_dir / "summary.csv"
 
     jsonl_files = sorted(base_dir.rglob("*.jsonl"))
+    empty_reason: Optional[str] = None
     if not jsonl_files:
         # Fallback: search one level up for legacy layouts
         parent_dir = base_dir.parent
@@ -693,6 +694,11 @@ def main() -> None:
                 except ValueError:
                     fallback.append(candidate)
         jsonl_files = sorted(fallback)
+        if not jsonl_files:
+            empty_reason = (
+                f"No usable rows in summary data — no *.jsonl files found under {base_dir}"
+            )
+            print(empty_reason)
 
     new_rows: List[Dict[str, str]] = []
     for path in jsonl_files:
@@ -718,6 +724,12 @@ def main() -> None:
     write_summary(summary_path, combined_rows)
     write_summary_md(base_dir, combined_rows)
     write_run_notes(base_dir, combined_rows)
+
+    if not combined_rows:
+        if empty_reason is None:
+            empty_reason = f"No usable rows in summary data — produced 0 rows under {base_dir}"
+            print(empty_reason)
+        sys.exit(3)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- make the REAL aggregator exit with a non-zero status when no rows are written, while still emitting the CSV artifacts
- surface clearer messaging when no jsonl files are discovered under the run directory
- add a workflow diagnostic step that dumps the run directory contents and previews the summary.csv in CI logs

## Testing
- python -m compileall scripts/aggregate_results.py

------
https://chatgpt.com/codex/tasks/task_e_68cfefada5188329ab95de0feb744c0f