### PR TITLE
Supersede #134/#141/#142/#143: unify REAL policy guard contract

### DIFF
--- a/policies/gates.py
+++ b/policies/gates.py
@@ -1,33 +1,98 @@
-"""
-Minimal policy gates for REAL runs.
+"""Minimal policy gates for REAL runs.
 
-Contract (stable, simple):
-  pre_call_guard(text: str, *, policy: str = "benign") -> tuple[bool, str]
-  post_call_guard(text: str, *, policy: str = "benign") -> tuple[bool, str]
+These helpers keep the dictionary-based contract that the rest of the
+codebase relies on while preserving the existing safety behaviour. Both guard
+functions return a mapping with stable keys so callers can continue to use
+``dict.get`` without breaking when the implementation changes underneath them.
 
-Return:
-  (allowed, reason) where 'reason' is a short human-readable string.
+Contract (stable):
+  ``pre_call_guard(text: str, *, policy: str = "benign") -> GuardResult``
+  ``post_call_guard(text: str, *, policy: str = "benign") -> GuardResult``
+
+Returned mapping keys:
+  ``allowed``      – ``True`` if the text passes the guard.
+  ``reason``       – short human-readable summary.
+  ``policy``       – name of the policy that ran.
+  ``stage``        – ``"pre"`` or ``"post"``.
+  ``pre_denied``   – only for pre guards; ``True`` when the guard blocks.
+  ``post_denied``  – only for post guards; ``True`` when the guard blocks.
+  ``post_pii_hit`` – only for post guards; ``True`` if PII was detected.
 """
 
 from __future__ import annotations
 
+import re
+from typing import Tuple, TypedDict
+
 DEFAULT_POLICY = "benign"
 
-def _always_allow(_: str, *, stage: str, policy: str) -> tuple[bool, str]:
-    return True, f"{stage}: {policy} — allow"
+_DENYLIST_KEYWORDS: Tuple[str, ...] = ("exfiltrate", "leak all", "dump all")
+_PII_REGEX = re.compile(r"(\b\d{3}[- ]?\d{2}[- ]?\d{4}\b|\b\d{13,19}\b)", re.IGNORECASE)
+
+
+class GuardResult(TypedDict, total=False):
+    allowed: bool
+    reason: str
+    policy: str
+    stage: str
+    pre_denied: bool
+    post_denied: bool
+    post_pii_hit: bool
+
+
+def _result(*, stage: str, policy: str, allowed: bool, reason: str, post_pii_hit: bool = False) -> GuardResult:
+    result: GuardResult = {
+        "allowed": allowed,
+        "reason": reason,
+        "policy": policy,
+        "stage": stage,
+    }
+    if stage == "pre":
+        result["pre_denied"] = not allowed
+    else:
+        result["post_denied"] = not allowed
+        result["post_pii_hit"] = post_pii_hit
+    return result
+
+
+def _always_allow(_: str, *, stage: str, policy: str) -> GuardResult:
+    return _result(stage=stage, policy=policy, allowed=True, reason=f"{stage}: {policy} — allow")
+
+
+def _denylist_pre_guard(text: str, *, stage: str, policy: str) -> GuardResult:
+    lowered = (text or "").lower()
+    if any(keyword in lowered for keyword in _DENYLIST_KEYWORDS):
+        return _result(stage=stage, policy=policy, allowed=False, reason="pre: denylist intent")
+    return _always_allow(text, stage=stage, policy=policy)
+
+
+def _pii_post_guard(text: str, *, stage: str, policy: str) -> GuardResult:
+    hit = bool(_PII_REGEX.search(text or ""))
+    if hit:
+        return _result(
+            stage=stage,
+            policy=policy,
+            allowed=False,
+            reason="post: possible PII detected",
+            post_pii_hit=True,
+        )
+    return _always_allow(text, stage=stage, policy=policy)
+
 
 # Hook points for future rules (regexes, matchers, policy files, etc.)
 _PRE_DISPATCH = {
-    "benign": _always_allow,
+    "benign": _denylist_pre_guard,
 }
 _POST_DISPATCH = {
-    "benign": _always_allow,
+    "benign": _pii_post_guard,
 }
 
-def pre_call_guard(text: str, *, policy: str = DEFAULT_POLICY) -> tuple[bool, str]:
+
+def pre_call_guard(text: str, *, policy: str = DEFAULT_POLICY) -> GuardResult:
     handler = _PRE_DISPATCH.get(policy, _always_allow)
     return handler(text, stage="pre", policy=policy)
 
-def post_call_guard(text: str, *, policy: str = DEFAULT_POLICY) -> tuple[bool, str]:
+
+def post_call_guard(text: str, *, policy: str = DEFAULT_POLICY) -> GuardResult:
     handler = _POST_DISPATCH.get(policy, _always_allow)
     return handler(text, stage="post", policy=policy)


### PR DESCRIPTION
## Supersedes
- [x] Supersedes [#143](https://github.com/jasonstan/doomarena-lab/pull/143) — ports the dictionary-based guard contract and denylist/PII heuristics in `policies/gates.py` (the workflow and artifact assertions from that PR already landed on `main`).
- [x] Supersedes [#142](https://github.com/jasonstan/doomarena-lab/pull/142) — `scripts/assert_real_artifacts.py` and the HTML head fixes from that PR are already present on `main`; no further diff required here.
- [x] Supersedes [#141](https://github.com/jasonstan/doomarena-lab/pull/141) — carries forward the structured guard result mapping and denylist/PII checks in `policies/gates.py`.
- [x] Supersedes [#134](https://github.com/jasonstan/doomarena-lab/pull/134) — the workflow renaming and artifact upload guardrails from that PR are already in `main`.

## What changed / Why
- Documented the REAL policy guard contract so callers know the stable keys and semantics they can rely on.
- Replaced the tuple return type with a `TypedDict` so guard metadata can be accessed via `dict.get` without runtime errors.
- Added a small denylist pre-guard to block obvious malicious intents before the REAL call runs.
- Strengthened the post-call guard with SSN/long-digit detection to flag likely PII in provider responses.
- Kept default behaviour permissive for future policies by falling back to the allow-all handler when an unknown policy name is supplied.

## Testing
- `make install`
- `RUN_ID=20250922-101830 make demo`
- `.venv/bin/python -m pytest -q`

Once this merges, maintainers can close #134, #141, #142, and #143.

------
https://chatgpt.com/codex/tasks/task_e_68d12099f090832996a1ba4eb19b4f89