### PR TITLE
Follow-up: Fix git grep option order for conflict scan

### DIFF
--- a/.github/workflows/no-conflict-markers.yml
+++ b/.github/workflows/no-conflict-markers.yml
@@ -21,7 +21,7 @@ jobs:
         run: |
           set -euo pipefail
           echo "Scanning tracked files for Git conflict markers..."
-          if git grep -nE '^(<{7}|={7}|>{7})' --color=never; then
+          if git grep --color=never -nE '^(<{7}|={7}|>{7})'; then
             echo "::error title=Conflict markers detected::Resolve all <<<<<<< ======= >>>>>>> sections before merging."
             exit 1
           fi


### PR DESCRIPTION
## Summary
- move the --color option before the pattern in the conflict marker scan so git grep runs successfully

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d131f63a10832985053c34b0684f5c