### PR TITLE
ci: add guardrails and clear RUN OK/WARN/FAIL messaging (EXP-004)

### DIFF
--- a/.github/workflows/run-real-mvp.yml
+++ b/.github/workflows/run-real-mvp.yml
@@ -38,6 +38,19 @@ jobs:
       - name: Install
         run: make install
 
+      - name: Pre-flight checks (env + imports)
+        run: |
+          PYBIN="python"
+          if [ -x ".venv/bin/python" ]; then
+            PYBIN=".venv/bin/python"
+          fi
+          "$PYBIN" tools/verify_latest_setup.py \
+            --skip-default-checks \
+            --require-env GROQ_API_KEY \
+            --require-import yaml \
+            --require-import pandas \
+            --require-import matplotlib
+
       - name: REAL run (set RUN_ID, execute, publish)
         id: real
         shell: bash
@@ -63,6 +76,29 @@ jobs:
           make report RUN_ID="${RUN_ID}"
           make latest
 
+
+      - name: Post-run data sanity
+        run: |
+          set -euo pipefail
+          RID="${RUN_ID:-}"
+          if [ -z "$RID" ] && [ -f results/.run_id ]; then
+            RID="$(cat results/.run_id)"
+          fi
+          if [ -z "$RID" ]; then
+            echo "FAIL: No data rows produced for <unknown run>. Check provider secret, network, or pre-gate denials."
+            exit 1
+          fi
+          ROWS_PATH="results/${RID}/tau_risky_real/rows.jsonl"
+          if [ ! -f "$ROWS_PATH" ]; then
+            echo "FAIL: No data rows produced for ${RID}. Check provider secret, network, or pre-gate denials."
+            exit 1
+          fi
+          non_empty_lines=$(grep -cve '^[[:space:]]*$' "$ROWS_PATH" || true)
+          if [ "$non_empty_lines" -eq 0 ]; then
+            echo "FAIL: No data rows produced for ${RID}. Check provider secret, network, or pre-gate denials."
+            exit 1
+          fi
+          echo "Post-run sanity check passed: ${non_empty_lines} row(s) present."
 
       - name: Verify REAL artifacts
         run: |

--- a/Makefile
+++ b/Makefile
@@ -143,9 +143,9 @@ topn:
 
 aggregate: ## Aggregate per-run CSV/notes into results/<RUN_DIR>
 	if [ -x "$(PY)" ]; then \
-		"$(PY)" scripts/aggregate_results.py --outdir "$(RUN_DIR)"; \
+		"$(PY)" scripts/aggregate_results.py --outdir "$(RUN_DIR)" --emit-status=always; \
 	else \
-		python scripts/aggregate_results.py --outdir "$(RUN_DIR)"; \
+		python scripts/aggregate_results.py --outdir "$(RUN_DIR)" --emit-status=always; \
 	fi
 
 plot: ## Plot results (safe wrapper creates placeholder SVG if empty)
@@ -169,9 +169,9 @@ test: install ## Run all Python tests
 
 notes: ## Auto-generate run notes if script is available
 	if [ -x "$(PY)" ]; then \
-		"$(PY)" scripts/aggregate_results.py --outdir "$(RUN_DIR)"; \
+		"$(PY)" scripts/aggregate_results.py --outdir "$(RUN_DIR)" --emit-status=never; \
 	else \
-		python scripts/aggregate_results.py --outdir "$(RUN_DIR)"; \
+		python scripts/aggregate_results.py --outdir "$(RUN_DIR)" --emit-status=never; \
 	fi
 
 report: aggregate plot notes latest ## Publish artifacts to results/ and refresh LATEST

--- a/tests/test_aggregate.py
+++ b/tests/test_aggregate.py
@@ -20,6 +20,16 @@ EXPECTED_COLUMNS = [
     "sum_cost_usd",
     "git_commit",
     "run_at",
+    "total_trials",
+    "pre_denied",
+    "called_trials",
+    "pass_rate",
+    "p50_ms",
+    "p95_ms",
+    "total_tokens",
+    "post_warn",
+    "post_deny",
+    "top_reason",
     "schema",
 ]
 

--- a/tests/test_summary_csv.py
+++ b/tests/test_summary_csv.py
@@ -18,6 +18,19 @@ BASE_COLUMNS = [
     "run_at",
 ]
 
+APPENDED_COLUMNS = [
+    "total_trials",
+    "pre_denied",
+    "called_trials",
+    "pass_rate",
+    "p50_ms",
+    "p95_ms",
+    "total_tokens",
+    "post_warn",
+    "post_deny",
+    "top_reason",
+]
+
 
 def test_summary_csv_present_and_valid():
     summary_path = Path("results/summary.csv")
@@ -27,10 +40,12 @@ def test_summary_csv_present_and_valid():
         reader = csv.DictReader(handle)
         assert reader.fieldnames is not None, "summary.csv missing header"
         header = [column.strip() for column in reader.fieldnames]
+        expected_prefix = BASE_COLUMNS + APPENDED_COLUMNS
         if header and header[-1] == "schema":
-            assert header[:-1] == BASE_COLUMNS, f"Unexpected header order: {header}"
+            core = header[:-1]
+            assert core == expected_prefix, f"Unexpected header order: {header}"
         else:
-            assert header == BASE_COLUMNS, f"Unexpected header order: {header}"
+            assert header == expected_prefix, f"Unexpected header order: {header}"
 
         valid_rows = 0
         for row in reader:

--- a/tools/verify_latest_setup.py
+++ b/tools/verify_latest_setup.py
@@ -1,84 +1,178 @@
 #!/usr/bin/env python3
-import re, sys
+"""Verify DoomArena latest-run wiring and optional CI pre-flight requirements."""
+
+from __future__ import annotations
+
+import argparse
+import importlib
+import os
+import re
+import sys
 from pathlib import Path
+from typing import Iterable, List, Sequence, Tuple
 
-repo = Path(__file__).resolve().parents[1]
-readme = repo / "README.md"
-makefile = repo / "Makefile"
-tools = repo / "tools"
 
-failures = []
-debug = []
+REPO_ROOT = Path(__file__).resolve().parents[1]
 
-def normalize(s: str) -> str:
-    # Map common unicode hyphens to ASCII and collapse whitespace
-    s = (s.replace("\u2010","-")
-           .replace("\u2011","-")
-           .replace("\u2012","-")
-           .replace("\u2013","-")
-           .replace("\u2014","-")
-           .replace("\u2015","-")
-           .replace("\u2212","-")
-           .replace("\xa0"," "))
-    s = re.sub(r"[ \t]+", " ", s)
-    return s
 
-def grep_snippet(txt: str, pattern: str, lines=3):
-    """Return a small snippet around the first match (for debug)."""
-    m = re.search(pattern, txt, re.M | re.I)
-    if not m:
+def normalize(text: str) -> str:
+    """Normalise unicode punctuation and collapse whitespace for regex searches."""
+
+    replacements = {
+        "\u2010": "-",
+        "\u2011": "-",
+        "\u2012": "-",
+        "\u2013": "-",
+        "\u2014": "-",
+        "\u2015": "-",
+        "\u2212": "-",
+        "\xa0": " ",
+    }
+    for needle, repl in replacements.items():
+        text = text.replace(needle, repl)
+    return re.sub(r"[ \t]+", " ", text)
+
+
+def grep_snippet(text: str, pattern: str) -> str:
+    match = re.search(pattern, text, re.M | re.I)
+    if not match:
         return "(no match)"
-    start = txt.rfind("\n", 0, m.start())
-    end = txt.find("\n", m.end())
-    if start < 0: start = 0
-    if end < 0: end = len(txt)
-    return txt[start:end].strip()
+    start = text.rfind("\n", 0, match.start())
+    end = text.find("\n", match.end())
+    if start < 0:
+        start = 0
+    if end < 0:
+        end = len(text)
+    return text[start:end].strip()
 
-# 1) README checks
-if not readme.exists():
-    failures.append("README.md is missing")
-else:
-    raw = readme.read_text(encoding="utf-8")
-    txt = normalize(raw)
 
-    # Accept any 'make  latest' with flexible whitespace
-    patt_latest = r"make\s+latest"
+def check_default_wiring() -> Tuple[List[str], List[str]]:
+    failures: List[str] = []
+    debug: List[str] = []
 
-    if not re.search(patt_latest, txt, re.I):
-        failures.append("README: missing 'make latest' mention")
-        debug.append("Snippet search latest: " + grep_snippet(txt, patt_latest))
+    readme = REPO_ROOT / "README.md"
+    makefile = REPO_ROOT / "Makefile"
+    tools_dir = REPO_ROOT / "tools"
+
+    if not readme.exists():
+        failures.append("README.md is missing")
     else:
-        debug.append("Found 'make latest': " + grep_snippet(txt, patt_latest))
+        raw = readme.read_text(encoding="utf-8")
+        txt = normalize(raw)
+        patt_latest = r"make\s+latest"
+        if not re.search(patt_latest, txt, re.I):
+            failures.append("README: missing 'make latest' mention")
+            debug.append("Snippet search latest: " + grep_snippet(txt, patt_latest))
+        else:
+            debug.append("Found 'make latest': " + grep_snippet(txt, patt_latest))
 
-# 2) Tools exist
-for p in ["latest_run.py"]:
-    if not (tools / p).exists():
-        failures.append(f"tools/{p} is missing")
+    if not (tools_dir / "latest_run.py").exists():
+        failures.append("tools/latest_run.py is missing")
 
-# 3) Makefile checks
-if not makefile.exists():
-    failures.append("Makefile is missing")
-else:
-    mtxt_raw = makefile.read_text(encoding="utf-8")
-    mtxt = normalize(mtxt_raw)
-    if not re.search(r"^latest:\s*$", mtxt, re.M):
-        failures.append("Makefile: missing 'latest:' target")
-    # report depends on latest (allow other prerequisites too, e.g., 'report: aggregate plot notes latest')
-    if not re.search(r"^report:\s*.*\blatest\b", mtxt, re.M):
-        failures.append("Makefile: 'report' does not depend on 'latest'")
+    if not makefile.exists():
+        failures.append("Makefile is missing")
+    else:
+        mtxt_raw = makefile.read_text(encoding="utf-8")
+        mtxt = normalize(mtxt_raw)
+        if not re.search(r"^latest:\s*$", mtxt, re.M):
+            failures.append("Makefile: missing 'latest:' target")
+        if not re.search(r"^report:\s*.*\blatest\b", mtxt, re.M):
+            failures.append("Makefile: 'report' does not depend on 'latest'")
 
-if failures:
-    print("VERIFICATION: FAIL")
-    for f in failures:
-        print(" -", f)
-    if debug:
-        print("\nDEBUG:")
-        for d in debug:
-            print(" *", d)
-    sys.exit(1)
-else:
+    return failures, debug
+
+
+def check_required_env(vars_to_check: Sequence[str]) -> List[str]:
+    failures: List[str] = []
+    for name in vars_to_check:
+        if not name:
+            continue
+        if not os.environ.get(name):
+            failures.append(
+                f"Missing required environment variable {name}. Set it in repository secrets or the runner environment."
+            )
+    return failures
+
+
+def check_required_imports(modules: Sequence[str]) -> List[str]:
+    failures: List[str] = []
+    for module in modules:
+        if not module:
+            continue
+        try:
+            importlib.import_module(module)
+        except Exception as exc:  # pragma: no cover - defensive logging only
+            failures.append(
+                "Missing Python module '{mod}'. Install dependencies via requirements-ci.txt (e.g. run 'make install'). (import "
+                "error: {err})".format(mod=module, err=exc)
+            )
+    return failures
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Verify latest-run wiring and optional CI pre-flight dependencies"
+    )
+    parser.add_argument(
+        "--require-env",
+        action="append",
+        default=[],
+        dest="require_env",
+        help="Environment variable that must be set (may be used multiple times)",
+    )
+    parser.add_argument(
+        "--require-import",
+        action="append",
+        default=[],
+        dest="require_import",
+        help="Python module that must import successfully (may be used multiple times)",
+    )
+    parser.add_argument(
+        "--skip-default-checks",
+        action="store_true",
+        help="Skip README/Makefile verification and only run explicit checks",
+    )
+    return parser
+
+
+def main(argv: Iterable[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(list(argv) if argv is not None else None)
+
+    failures: List[str] = []
+    debug_messages: List[str] = []
+
+    if not args.skip_default_checks:
+        default_failures, default_debug = check_default_wiring()
+        failures.extend(default_failures)
+        debug_messages.extend(default_debug)
+
+    failures.extend(check_required_env(args.require_env))
+    failures.extend(check_required_imports(args.require_import))
+
+    if failures:
+        print("VERIFICATION: FAIL")
+        for item in failures:
+            print(" -", item)
+        if debug_messages:
+            print("\nDEBUG:")
+            for entry in debug_messages:
+                print(" *", entry)
+        return 1
+
     print("VERIFICATION: PASS")
-    print(" - README mentions 'make latest'")
-    print(" - tools/latest_run.py present")
-    print(" - Makefile has 'latest' target and 'report: latest' dependency")
-    sys.exit(0)
+    if not args.skip_default_checks:
+        print(" - README mentions 'make latest'")
+        print(" - tools/latest_run.py present")
+        print(" - Makefile has 'latest' target and 'report: latest' dependency")
+    if args.require_env:
+        joined = ", ".join(args.require_env)
+        print(f" - Required environment variables present: {joined}")
+    if args.require_import:
+        joined = ", ".join(args.require_import)
+        print(f" - Required Python modules importable: {joined}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add CI preflight step that verifies GROQ_API_KEY and required imports before running REAL slices
- fail fast when rows.jsonl is missing or empty while keeping reports in place and emitting RUN OK/WARN/FAIL summaries
- surface aggregation status in HTML/report artifacts and update tests to expect the expanded summary columns

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d17808fc888329b194455e9d027a7f