### PR TITLE
limits: add run-level cost & volume controls with reporting (EXP-005)

### DIFF
--- a/.github/workflows/run-real-mvp.yml
+++ b/.github/workflows/run-real-mvp.yml
@@ -15,6 +15,44 @@ on:
         description: "Comma-separated seeds"
         required: true
         default: "41,42"
+      max_trails:
+        description: "Optional max-trials override (typo-safe input)"
+        required: false
+        default: ""
+      max_trials:
+        description: "Optional cap on callable trials"
+        required: false
+        default: ""
+      max_total_tokens:
+        description: "Optional run-level total token ceiling"
+        required: false
+        default: ""
+      max_prompt_tokens:
+        description: "Optional prompt token ceiling"
+        required: false
+        default: ""
+      max_completion_tokens:
+        description: "Optional completion token ceiling"
+        required: false
+        default: ""
+      max_calls:
+        description: "Optional provider call cap"
+        required: false
+        default: ""
+      temperature:
+        description: "Optional sampling temperature override"
+        required: false
+        default: ""
+      dry_run:
+        description: "Skip provider calls (dry run)"
+        required: false
+        type: boolean
+        default: false
+      fail_on_budget:
+        description: "Exit non-zero when a budget limit is hit"
+        required: false
+        type: boolean
+        default: false
 
 # Need write to publish artifacts; keep repo read
 permissions:
@@ -70,6 +108,34 @@ jobs:
 
           # Execute the REAL risky run (Groq) via make
           # Target should read REAL_MODEL/TRIALS/SEEDS from env and honor RUN_ID
+          MAX_TRAILS_INPUT="${{ inputs.max_trails }}"
+          MAX_TRIALS_INPUT="${{ inputs.max_trials }}"
+          if [ -n "$MAX_TRAILS_INPUT" ]; then
+            export MAX_TRIALS="$MAX_TRAILS_INPUT"
+          elif [ -n "$MAX_TRIALS_INPUT" ]; then
+            export MAX_TRIALS="$MAX_TRIALS_INPUT"
+          fi
+          if [ -n "${{ inputs.max_total_tokens }}" ]; then
+            export MAX_TOTAL_TOKENS="${{ inputs.max_total_tokens }}"
+          fi
+          if [ -n "${{ inputs.max_prompt_tokens }}" ]; then
+            export MAX_PROMPT_TOKENS="${{ inputs.max_prompt_tokens }}"
+          fi
+          if [ -n "${{ inputs.max_completion_tokens }}" ]; then
+            export MAX_COMPLETION_TOKENS="${{ inputs.max_completion_tokens }}"
+          fi
+          if [ -n "${{ inputs.max_calls }}" ]; then
+            export MAX_CALLS="${{ inputs.max_calls }}"
+          fi
+          if [ -n "${{ inputs.temperature }}" ]; then
+            export TEMPERATURE="${{ inputs.temperature }}"
+          fi
+          if [ "${{ inputs.dry_run }}" = 'true' ]; then
+            export DRY_RUN=1
+          fi
+          if [ "${{ inputs.fail_on_budget }}" = 'true' ]; then
+            export FAIL_ON_BUDGET=1
+          fi
           make real-tau-risky TRIALS="${TRIALS}" SEEDS="${SEEDS}" REAL_MODEL="${REAL_MODEL}"
 
           # Create report & update LATEST marker

--- a/README.md
+++ b/README.md
@@ -62,6 +62,28 @@ results/LATEST/{summary.csv,summary.svg,index.html}
 - Provide **SHIM** simulation adapters for deterministic demos and a **REAL** path to cloud models.
 - Keep runs **cheap, auditable, and explainable** (governance signals + metrics).
 
+### Cost & volume controls
+- `--max-trials` — optional cap on callable trials (defaults to `--trials` value)
+- `--max-total-tokens` — run-level total token ceiling (default `100000`)
+- `--max-prompt-tokens` — prompt token ceiling (default `80000`)
+- `--max-completion-tokens` — completion token ceiling (default `40000`)
+- `--max-calls` — cap provider calls for the run (no cap by default)
+- `--temperature` — sampling temperature (default `0.2`)
+- `--dry-run` — exercise gating/bookkeeping without calling the provider
+- `--fail-on-budget` — exit non-zero if any ceiling is reached
+
+Example:
+
+```
+python -m scripts.experiments.tau_risky_real \
+  --trials 6 \
+  --max-total-tokens 5000 \
+  --max-calls 2 \
+  --fail-on-budget
+```
+
+The GitHub Action exposes the same inputs (`max_trails`/`max_trials`, `max_total_tokens`, `max_prompt_tokens`, `max_completion_tokens`, `max_calls`, `temperature`, `dry_run`, `fail_on_budget`). Run outputs include a single `BUDGET:` line plus budget usage in `run.json`, `summary.csv`, and `index.html`.
+
 ## Artifacts & schema
 - Each run writes to `results/<RUN_ID>/`; convenience copies go to `results/LATEST/*`.
 - Canonical files in `results/<RUN_ID>/`:

--- a/reports/templates/index.html
+++ b/reports/templates/index.html
@@ -63,6 +63,15 @@
         grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
         gap: 14px;
       }
+      .overview-header {
+        display: flex;
+        align-items: center;
+        gap: 12px;
+        margin-bottom: 8px;
+      }
+      .overview-header h2 {
+        margin: 0;
+      }
       .overview-card {
         background: #ffffff;
         padding: 16px;
@@ -72,6 +81,18 @@
       .overview-pass {
         background: linear-gradient(135deg, #1e293b, #0f172a);
         color: #f8fafc;
+      }
+      .badge {
+        display: inline-flex;
+        align-items: center;
+        padding: 4px 10px;
+        border-radius: 999px;
+        font-size: 12px;
+        font-weight: 600;
+      }
+      .badge-warn {
+        background: #fef3c7;
+        color: #92400e;
       }
       .overview-card .label {
         font-size: 12px;
@@ -88,6 +109,11 @@
         font-size: 13px;
         margin-top: 4px;
         opacity: 0.85;
+      }
+      .overview-budget {
+        margin-top: 12px;
+        font-size: 14px;
+        color: #52606d;
       }
       table {
         border-collapse: collapse;
@@ -146,6 +172,10 @@
           background: #1f2937;
           box-shadow: 0 1px 2px rgba(0, 0, 0, 0.35);
         }
+        .badge-warn {
+          background: rgba(253, 224, 71, 0.25);
+          color: #fcd34d;
+        }
         table {
           background: #1f2937;
           box-shadow: 0 1px 2px rgba(0, 0, 0, 0.35);
@@ -155,6 +185,9 @@
         }
         td, th {
           border-color: #374151;
+        }
+        .overview-budget {
+          color: #94a3b8;
         }
         .artifact-list .missing {
           color: #94a3b8;
@@ -169,7 +202,10 @@
     </header>
     $BANNERS
     <section>
-      <h2>Overview</h2>
+      <div class="overview-header">
+        <h2>Overview</h2>
+        $OVERVIEW_BADGE
+      </div>
       $OVERVIEW
     </section>
     <section>


### PR DESCRIPTION
## Summary
- add per-run limit tracking to the REAL risky slice (tau_risky_real) including new CLI/env flags, dry-run mode, budget-aware rows, run.json usage metadata, and a single BUDGET summary line
- surface budget usage throughout aggregation: append columns in summary.csv, include usage/budget blocks in run_report.json, and render the new line/badge in index.html (template + mk_report helper updates)
- expose matching inputs in the run-real-mvp workflow and document the cost & volume controls in the README

## Testing
- `python -m compileall scripts/experiments/tau_risky_real.py scripts/aggregate_results.py tools/mk_report.py`


------
https://chatgpt.com/codex/tasks/task_e_68d18b9affc88329a4300f3e9d019609