### PR TITLE
Fix CI dependencies and update summary schema tests

### DIFF
--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -3,3 +3,4 @@ doomarena-taubench
 pytest
 pyyaml
 matplotlib
+pandas

--- a/tests/test_aggregate.py
+++ b/tests/test_aggregate.py
@@ -30,6 +30,12 @@ EXPECTED_COLUMNS = [
     "post_warn",
     "post_deny",
     "top_reason",
+    "calls_made",
+    "tokens_prompt_sum",
+    "tokens_completion_sum",
+    "tokens_total_sum",
+    "stopped_early",
+    "budget_hit",
     "schema",
 ]
 

--- a/tests/test_summary_csv.py
+++ b/tests/test_summary_csv.py
@@ -29,6 +29,12 @@ APPENDED_COLUMNS = [
     "post_warn",
     "post_deny",
     "top_reason",
+    "calls_made",
+    "tokens_prompt_sum",
+    "tokens_completion_sum",
+    "tokens_total_sum",
+    "stopped_early",
+    "budget_hit",
 ]
 
 


### PR DESCRIPTION
## Summary
- add pandas to the CI requirements so pytest runs have the dataframe dependency available
- extend the summary CSV schema expectations in the tests to include the new metrics columns

## Testing
- .venv/bin/pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d19876da7883299c9942b4b5c3fc33