### PR TITLE
CI hotfix: install aggregator deps before preflight

### DIFF
--- a/.github/workflows/run-real-mvp.yml
+++ b/.github/workflows/run-real-mvp.yml
@@ -76,7 +76,7 @@ jobs:
           python-version: "3.11"
 
       - name: Install
-        run: make install
+        run: pip install -r requirements-ci.txt
 
       - name: Set RUN_ID
         run: echo "RUN_ID=$(date -u +'%Y-%m-%dT%H-%M-%SZ')" >> $GITHUB_ENV

--- a/.github/workflows/run-real-tau-risky.yml
+++ b/.github/workflows/run-real-tau-risky.yml
@@ -29,7 +29,7 @@ jobs:
         with: { python-version: "3.11" }
 
       - name: Install
-        run: make install
+        run: pip install -r requirements-ci.txt
 
       - name: Set RUN_ID
         run: echo "RUN_ID=$(date -u +'%Y-%m-%dT%H-%M-%SZ')" >> $GITHUB_ENV

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@
 export GROQ_API_KEY=...
 
 # 2) Run the REAL slice locally (cheap default)
+pip install -r requirements-ci.txt   # or: make install
 python -m scripts.experiments.tau_risky_real --trials 6 --seed 42
 
 # 3) Build report

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -5,3 +5,5 @@ pyyaml
 matplotlib
 pandas
 requests>=2.31,<3.0
+pandas>=2.2.2,<2.3
+numpy>=1.26.4,<2.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,3 +4,5 @@ pyyaml
 pandas
 matplotlib
 requests>=2.31,<3.0
+pandas>=2.2.2,<2.3
+numpy>=1.26.4,<2.0


### PR DESCRIPTION
## Summary
- add explicit pandas/numpy pins to CI and dev requirements for aggregator support
- update real run workflows to install requirements-ci.txt prior to preflight checks
- document the CI requirements install command in the Quickstart guide

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d1e3119fb8832991d1b8ac367b2ab1