### PR TITLE
CI hotfix: pin Python 3.11 and add matplotlib

### DIFF
--- a/.github/workflows/run-real-mvp.yml
+++ b/.github/workflows/run-real-mvp.yml
@@ -73,7 +73,7 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: '3.11'
 
       - name: Install
         run: pip install -r requirements-ci.txt

--- a/.github/workflows/run-real-tau-risky.yml
+++ b/.github/workflows/run-real-tau-risky.yml
@@ -26,7 +26,8 @@ jobs:
       - uses: actions/checkout@v4
 
       - uses: actions/setup-python@v5
-        with: { python-version: "3.11" }
+        with:
+          python-version: '3.11'
 
       - name: Install
         run: pip install -r requirements-ci.txt

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -2,8 +2,7 @@ doomarena
 doomarena-taubench
 pytest
 pyyaml
-matplotlib
-pandas
 requests>=2.31,<3.0
-pandas>=2.2.2,<2.3
 numpy>=1.26.4,<2.0
+pandas>=2.2.2,<2.3
+matplotlib>=3.8,<3.9

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,8 +1,7 @@
 # Dev/test deps (keep light; match Makefile install)
 pytest
 pyyaml
-pandas
-matplotlib
 requests>=2.31,<3.0
-pandas>=2.2.2,<2.3
 numpy>=1.26.4,<2.0
+pandas>=2.2.2,<2.3
+matplotlib>=3.8,<3.9


### PR DESCRIPTION
## Summary
- pin the REAL workflows to Python 3.11 in GitHub Actions
- ensure numpy, pandas, and matplotlib are pinned compatibly for pre-flight checks in CI and dev setups

## Testing
- not run (workflow-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d1e73067148329bcf6147b8a4f7279