### PR TITLE
ci: align tau-risky workflow python interpreter

### DIFF
--- a/.github/workflows/run-real-tau-risky.yml
+++ b/.github/workflows/run-real-tau-risky.yml
@@ -30,7 +30,32 @@ jobs:
           python-version: '3.11'
 
       - name: Install
-        run: pip install -r requirements-ci.txt
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r requirements-ci.txt
+
+      - name: Show Python and deps
+        run: |
+          python -c "import sys; print('PY', sys.version)"
+          python -c "import numpy, pandas, matplotlib; print('NP', numpy.__version__, 'PD', pandas.__version__, 'MP', matplotlib.__version__)"
+
+      - name: Pre-flight checks (imports only)
+        run: |
+          python - <<'PY'
+          import importlib, sys
+          missing = []
+          for mod in ("numpy","pandas","matplotlib"):
+              try:
+                  importlib.import_module(mod)
+              except Exception as e:
+                  missing.append((mod, repr(e)))
+          if missing:
+              print("VERIFICATION: FAIL")
+              for mod, err in missing:
+                  print(f"- Missing Python module '{mod}'. Install via requirements-ci.txt. (import error: {err})")
+              sys.exit(1)
+          print("VERIFICATION: OK")
+          PY
 
       - name: Set RUN_ID
         run: echo "RUN_ID=$(date -u +'%Y-%m-%dT%H-%M-%SZ')" >> $GITHUB_ENV


### PR DESCRIPTION
## Summary
- install requirements for the real tau risky workflow using python -m pip under the pinned Python 3.11 interpreter
- add diagnostics to show interpreter and core dependency versions before running the job
- gate the run with a python-based import pre-flight to surface missing numpy/pandas/matplotlib

## Testing
- not run (workflow change)


------
https://chatgpt.com/codex/tasks/task_e_68d1eb2fe2d08329813713cc4c181fd4