### PR TITLE
Add REAL CLI drift tests and unmask latest failures

### DIFF
--- a/.github/workflows/run-demo.yml
+++ b/.github/workflows/run-demo.yml
@@ -46,21 +46,28 @@ jobs:
         run: |
           make demo TRIALS="${TRIALS}" SEEDS="${SEEDS}" MODE="${MODE}" RUN_ID="${RUN_ID}"
 
-      - name: Report + publish LATEST
+      - name: Report run outputs
         env:
           RUN_ID: ${{ env.RUN_ID }}
         run: |
           make report RUN_ID="${RUN_ID}"
-          make latest || true
+
+      - name: Refresh latest pointer
+        run: make latest
+
+      - name: On latest failure, print context
+        if: failure()
+        run: echo "ERR: latest pointer failed; check tools/latest_run.py and artifacts from previous steps."
 
       - name: Tidy run directory (remove duplicates)
+        if: ${{ always() }}
         env:
           RUN_ID: ${{ env.RUN_ID }}
         run: |
           make tidy-run RUN_ID="${RUN_ID}"
 
       - name: Upload full RUN_DIR
-        if: ${{ steps.set-run-id.outputs.run_id != '' }}
+        if: ${{ always() && steps.set-run-id.outputs.run_id != '' }}
         uses: actions/upload-artifact@v4
         with:
           name: run-${{ env.RUN_ID }}
@@ -69,6 +76,7 @@ jobs:
           retention-days: 7
 
       - name: Upload latest artifacts (from results/)
+        if: ${{ always() }}
         uses: actions/upload-artifact@v4
         with:
           name: latest-artifacts

--- a/Makefile
+++ b/Makefile
@@ -219,7 +219,12 @@ ci: install ## CI entrypoint: minimal sweep & report (used in smoke)
 
 .PHONY: latest
 latest:
-	@$(PYTHON) tools/latest_run.py $(RESULTS_DIR) $(LATEST_LINK) || true
+	@if $(PYTHON) tools/latest_run.py $(RESULTS_DIR) $(LATEST_LINK); then \
+		: ; \
+	else \
+		echo "ERROR: failed to update results/LATEST; see logs" >&2; \
+		exit 1; \
+	fi
 
 tidy-run: ## Remove redundant files in results/$(RUN_ID) (timestamped copies, PNG)
 	@d="results/$(RUN_ID)"; \

--- a/README.md
+++ b/README.md
@@ -41,11 +41,12 @@
 
 ## Quickstart
 ```bash
+pip install -r requirements-ci.txt   # or: make install
+
 # 1) Set provider secret
 export GROQ_API_KEY=...
 
 # 2) Run the REAL slice locally (cheap default)
-pip install -r requirements-ci.txt   # or: make install
 python -m scripts.experiments.tau_risky_real --trials 6 --seed 42
 
 # 3) Build report

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,16 @@
-import os, sys
+import os
+import sys
+
+import pytest
 
 ROOT = os.path.dirname(os.path.dirname(__file__))
 sys.path.append(ROOT)
 sys.path.append(os.path.join(ROOT, "scripts"))
+
+
+@pytest.fixture
+def run_in_tmp(tmp_path, monkeypatch):
+    """Change into a temporary working directory for CLI smoke tests."""
+
+    monkeypatch.chdir(tmp_path)
+    return tmp_path

--- a/tests/test_tau_risky_real_cli.py
+++ b/tests/test_tau_risky_real_cli.py
@@ -1,0 +1,173 @@
+import json
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+CLI_MODULE = "scripts.experiments.tau_risky_real"
+AGGREGATE_MODULE = "scripts.aggregate_results"
+RUN_PATTERN = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}Z$")
+
+
+def _base_env(*, prepend: list[Path] | None = None) -> dict[str, str]:
+    env = os.environ.copy()
+    existing = env.get("PYTHONPATH")
+    paths: list[str] = []
+    if prepend:
+        paths.extend(str(path) for path in prepend)
+    paths.append(str(REPO_ROOT))
+    if existing:
+        paths.append(existing)
+    env["PYTHONPATH"] = os.pathsep.join(paths)
+    return env
+
+
+def _cli_env(workdir: Path, overrides: dict[str, str] | None = None) -> dict[str, str]:
+    env = _base_env(prepend=[workdir])
+    env.setdefault("GROQ_API_KEY", "test-key")
+    if overrides:
+        env.update(overrides)
+    return env
+
+
+def _ensure_requests_stub(workdir: Path) -> None:
+    stub_path = workdir / "requests.py"
+    if stub_path.exists():
+        return
+    stub_path.write_text(
+        "def post(*args, **kwargs):\n"
+        "    raise AssertionError('requests.post stub should not be called during dry-run tests')\n",
+        encoding="utf-8",
+    )
+
+
+def _run_module(module: str, args: list[str], *, cwd: Path, env: dict[str, str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, "-m", module, *args],
+        cwd=cwd,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+
+
+def _run_script(script_path: Path, args: list[str], *, cwd: Path, env: dict[str, str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(script_path), *args],
+        cwd=cwd,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+
+
+def _read_run_id(workdir: Path) -> str:
+    marker = workdir / "results" / ".run_id"
+    assert marker.exists(), ".run_id marker missing"
+    run_id = marker.read_text(encoding="utf-8").strip()
+    assert run_id, "run_id marker is empty"
+    assert RUN_PATTERN.match(run_id), f"run_id not ISO-ish: {run_id!r}"
+    return run_id
+
+
+def _load_run_json(workdir: Path, run_id: str) -> dict[str, object]:
+    run_json_path = workdir / "results" / run_id / "tau_risky_real" / "run.json"
+    assert run_json_path.exists(), "run.json missing"
+    return json.loads(run_json_path.read_text(encoding="utf-8"))
+
+
+def _load_rows(path: Path) -> list[dict[str, object]]:
+    assert path.exists(), f"rows file missing at {path}"
+    lines = [line for line in path.read_text(encoding="utf-8").splitlines() if line.strip()]
+    assert lines, "rows.jsonl is empty"
+    return [json.loads(line) for line in lines]
+
+
+def test_cli_accepts_legacy_flags(run_in_tmp: Path) -> None:
+    _ensure_requests_stub(run_in_tmp)
+    result = _run_module(
+        CLI_MODULE,
+        [
+            "--seeds",
+            "7",
+            "--outdir",
+            "results",
+            "--risk",
+            "refund",
+            "--dry-run",
+            "--trials",
+            "1",
+        ],
+        cwd=run_in_tmp,
+        env=_cli_env(run_in_tmp),
+    )
+    assert result.returncode == 0
+
+
+def test_cli_prefers_seed_over_seeds(run_in_tmp: Path) -> None:
+    _ensure_requests_stub(run_in_tmp)
+    result = _run_module(
+        CLI_MODULE,
+        [
+            "--seed",
+            "314",
+            "--seeds",
+            "7",
+            "--dry-run",
+            "--trials",
+            "1",
+        ],
+        cwd=run_in_tmp,
+        env=_cli_env(run_in_tmp),
+    )
+    assert "note: both seeds provided; using --seed." in result.stdout
+    run_id = _read_run_id(run_in_tmp)
+    run_meta = _load_run_json(run_in_tmp, run_id)
+    assert run_meta.get("seed") == 314
+
+
+def test_cli_dry_run_writes_marker_and_artifacts(run_in_tmp: Path) -> None:
+    _ensure_requests_stub(run_in_tmp)
+    _run_module(
+        CLI_MODULE,
+        ["--dry-run", "--trials", "1", "--seed", "1"],
+        cwd=run_in_tmp,
+        env=_cli_env(run_in_tmp),
+    )
+    run_id = _read_run_id(run_in_tmp)
+    run_root = run_in_tmp / "results" / run_id
+    exp_dir = run_root / "tau_risky_real"
+    assert exp_dir.is_dir(), "experiment directory missing"
+
+    rows_path = exp_dir / "rows.jsonl"
+    rows = _load_rows(rows_path)
+    assert all(row.get("fail_reason") == "DRY_RUN" for row in rows)
+
+    run_meta = _load_run_json(run_in_tmp, run_id)
+    usage = run_meta.get("usage", {}) if isinstance(run_meta, dict) else {}
+    assert usage.get("calls_made") == 0
+    assert usage.get("tokens_total_sum") == 0
+
+    aggregate_env = _base_env()
+    _run_module(
+        AGGREGATE_MODULE,
+        ["--outdir", str(run_root)],
+        cwd=run_in_tmp,
+        env=aggregate_env,
+    )
+
+    summary_csv = run_root / "summary.csv"
+    assert summary_csv.exists(), "summary.csv not produced"
+    summary_text = summary_csv.read_text(encoding="utf-8").strip()
+    assert summary_text, "summary.csv is empty"
+
+    mk_report_env = _base_env()
+    _run_script(REPO_ROOT / "tools" / "mk_report.py", [str(run_root)], cwd=run_in_tmp, env=mk_report_env)
+    index_html = run_root / "index.html"
+    assert index_html.exists(), "index.html not generated"
+    html_text = index_html.read_text(encoding="utf-8").strip()
+    assert html_text.lower().startswith("<!doctype html>")


### PR DESCRIPTION
## Summary
- add integration-style tests that exercise the tau_risky_real CLI using legacy flags, seed precedence, and dry-run aggregation outputs
- provide a pytest fixture to run commands in a temporary working directory with a stubbed requests module to avoid external calls
- stop masking `make latest` failures in the demo workflow/Makefile and surface an explicit README install prerequisite

## Testing
- `pytest tests/test_tau_risky_real_cli.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68d26f33a01883299164685d61f851fa