### PR TITLE
ci: fix YAML syntax by normalizing heredocs and shells in run-real-mvp.yml and run-demo.yml

### DIFF
--- a/.github/workflows/run-demo.yml
+++ b/.github/workflows/run-demo.yml
@@ -28,6 +28,7 @@ jobs:
 
       - name: Set RUN_ID (once)
         id: set-run-id
+        shell: bash
         run: |
           RUN_ID="$(date -u +%Y%m%d-%H%M%S)"
           echo "RUN_ID=$RUN_ID" >> "$GITHUB_ENV"
@@ -35,6 +36,7 @@ jobs:
           echo "RUN_ID=$RUN_ID"
 
       - name: Install
+        shell: bash
         run: make install
 
       - name: Run demo (single RUN_ID with both experiments)
@@ -43,26 +45,31 @@ jobs:
           SEEDS: ${{ inputs.seeds }}
           MODE: ${{ inputs.mode }}
           RUN_ID: ${{ env.RUN_ID }}
+        shell: bash
         run: |
           make demo TRIALS="${TRIALS}" SEEDS="${SEEDS}" MODE="${MODE}" RUN_ID="${RUN_ID}"
 
       - name: Report run outputs
         env:
           RUN_ID: ${{ env.RUN_ID }}
+        shell: bash
         run: |
           make report RUN_ID="${RUN_ID}"
 
       - name: Refresh latest pointer
+        shell: bash
         run: make latest
 
       - name: On latest failure, print context
         if: failure()
+        shell: bash
         run: echo "ERR: latest pointer failed; check tools/latest_run.py and artifacts from previous steps."
 
       - name: Tidy run directory (remove duplicates)
         if: ${{ always() }}
         env:
           RUN_ID: ${{ env.RUN_ID }}
+        shell: bash
         run: |
           make tidy-run RUN_ID="${RUN_ID}"
 

--- a/.github/workflows/run-real-mvp.yml
+++ b/.github/workflows/run-real-mvp.yml
@@ -76,28 +76,33 @@ jobs:
           python-version: '3.11'
 
       - name: Install
+        shell: bash
         run: |
           python -m pip install --upgrade pip
           python -m pip install -r requirements-ci.txt
 
       - name: Set RUN_ID
+        shell: bash
         run: echo "RUN_ID=$(date -u +'%Y-%m-%dT%H-%M-%SZ')" >> $GITHUB_ENV
 
       - name: Pre-flight checks (imports only)
+        shell: bash
         run: python tools/ci_preflight.py
 
       - name: Show Python and dep versions
+        shell: bash
         run: |
           python - <<'PY'
-import sys, numpy, pandas, matplotlib
-print("PY:", sys.version)
-print("NP:", numpy.__version__, "PD:", pandas.__version__, "MP:", matplotlib.__version__)
-PY
+          import sys, numpy, pandas, matplotlib
+          print("PY:", sys.version)
+          print("NP:", numpy.__version__, "PD:", pandas.__version__, "MP:", matplotlib.__version__)
+          PY
 
       - name: Pre-flight checks (env + imports)
         if: github.event_name != 'pull_request'
         env:
           GROQ_API_KEY: ${{ secrets.GROQ_API_KEY }}
+        shell: bash
         run: |
           PYBIN="python"
           if [ -x ".venv/bin/python" ]; then
@@ -112,6 +117,7 @@ PY
         env:
           GROQ_API_KEY: dry-run-placeholder
           RUN_ID: ${{ env.RUN_ID }}
+        shell: bash
         run: |
           set -euo pipefail
           PYBIN="python"
@@ -129,6 +135,7 @@ PY
         env:
           GROQ_API_KEY: ${{ secrets.GROQ_API_KEY }}
           RUN_ID: ${{ env.RUN_ID }}
+        shell: bash
         run: |
           set -euo pipefail
           PYBIN="python"
@@ -181,6 +188,7 @@ PY
         env:
           GROQ_API_KEY: ${{ secrets.GROQ_API_KEY }}
           RUN_ID: ${{ env.RUN_ID }}
+        shell: bash
         run: |
           set -euo pipefail
           PYBIN="python"
@@ -235,6 +243,7 @@ PY
       - name: Ensure run_id marker
         env:
           RUN_ID: ${{ env.RUN_ID }}
+        shell: bash
         run: |
           mkdir -p results
           if [ ! -f results/.run_id ]; then
@@ -244,6 +253,7 @@ PY
       - name: Generate report & publish latest
         env:
           RUN_ID: ${{ env.RUN_ID }}
+        shell: bash
         run: |
           make report RUN_ID="${RUN_ID}"
           make latest
@@ -252,6 +262,7 @@ PY
         env:
           EVENT_NAME: ${{ github.event_name }}
           RUN_ID: ${{ env.RUN_ID }}
+        shell: bash
         run: |
           set -euo pipefail
           RID="${RUN_ID:-}"
@@ -287,6 +298,7 @@ PY
           echo "Post-run sanity check passed: ${non_empty_lines} row(s) present."
 
       - name: Verify REAL artifacts
+        shell: bash
         run: |
           PYBIN="python"
           if [ -x ".venv/bin/python" ]; then
@@ -300,6 +312,7 @@ PY
 
       - name: Diagnose outputs (list RUN_DIR and preview CSV)
         if: always()
+        shell: bash
         run: |
           RID="${RUN_ID:-}"
           if [ -z "$RID" ] && [ -f results/.run_id ]; then


### PR DESCRIPTION
## Summary
- ensure every run step explicitly uses the bash shell in the run-real-mvp and run-demo workflows
- replace heredoc usages with properly indented bash block scalars so YAML parses cleanly while keeping commands unchanged

## Testing
- not run (workflow-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68d27dc94514832992753ad14376008f