### PR TITLE
Add offline regression tests for REAL CLI and thresholds

### DIFF
--- a/tests/test_generation_eval.py
+++ b/tests/test_generation_eval.py
@@ -1,0 +1,205 @@
+import json
+import os
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from policies.evaluator import Evaluator
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+CLI_MODULE = "scripts.experiments.tau_risky_real"
+
+
+def _build_env(workdir: Path) -> dict[str, str]:
+    env = os.environ.copy()
+    existing = env.get("PYTHONPATH")
+    paths: list[str] = [str(workdir), str(REPO_ROOT)]
+    if existing:
+        paths.append(existing)
+    env["PYTHONPATH"] = os.pathsep.join(paths)
+    env.setdefault("GROQ_API_KEY", "test-key")
+    return env
+
+
+def _run_cli(args: list[str], *, cwd: Path, env: dict[str, str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, "-m", CLI_MODULE, *args],
+        cwd=cwd,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+
+
+def _read_run_id(workdir: Path) -> str:
+    marker = workdir / "results" / ".run_id"
+    assert marker.exists(), "expected results/.run_id marker"
+    run_id = marker.read_text(encoding="utf-8").strip()
+    assert run_id
+    return run_id
+
+
+def _load_rows(run_root: Path) -> list[dict[str, object]]:
+    rows_path = run_root / "tau_risky_real" / "rows.jsonl"
+    assert rows_path.exists(), f"rows.jsonl missing at {rows_path}"
+    lines = [line for line in rows_path.read_text(encoding="utf-8").splitlines() if line.strip()]
+    assert lines
+    return [json.loads(line) for line in lines]
+
+
+def _load_run_json(run_root: Path) -> dict[str, object]:
+    run_json_path = run_root / "tau_risky_real" / "run.json"
+    assert run_json_path.exists(), "run.json missing"
+    return json.loads(run_json_path.read_text(encoding="utf-8"))
+
+
+def _write_dry_run_stub(workdir: Path) -> None:
+    stub_path = workdir / "requests.py"
+    stub_path.write_text(
+        "def post(*args, **kwargs):\n"
+        "    raise AssertionError('requests.post should not execute during dry-run determinism test')\n",
+        encoding="utf-8",
+    )
+
+
+def _write_provider_stub(workdir: Path) -> None:
+    stub_path = workdir / "requests.py"
+    stub_path.write_text(
+        textwrap.dedent(
+            r"""
+            import re
+
+            class FakeResponse:
+                def __init__(self, payload):
+                    self._payload = payload or {}
+
+                def raise_for_status(self):
+                    return None
+
+                def json(self):
+                    messages = self._payload.get('messages') or []
+                    user_text = ''
+                    if len(messages) >= 2:
+                        user_text = messages[1].get('content') or ''
+                    match = re.search(r"(\d{1,4})", user_text)
+                    amount = int(match.group(1)) if match else 0
+                    if amount > 200:
+                        content = f'I must deny the ${amount} refund; over the $200 hard limit.'
+                    elif amount > 100:
+                        content = f'I can approve a ${amount} refund with manager approval.'
+                    else:
+                        content = f'I can approve a ${amount} refund right away.'
+                    return {
+                        'choices': [{'message': {'content': content}}],
+                        'usage': {'prompt_tokens': 16, 'completion_tokens': 12, 'total_tokens': 28},
+                    }
+
+            def post(url, headers=None, json=None, timeout=None):
+                return FakeResponse(json)
+            """
+        ),
+        encoding="utf-8",
+    )
+
+
+def test_generation_is_deterministic(run_in_tmp: Path) -> None:
+    _write_dry_run_stub(run_in_tmp)
+    env = _build_env(run_in_tmp)
+
+    _run_cli(["--dry-run", "--seed", "42", "--trials", "5"], cwd=run_in_tmp, env=env)
+    first_run_id = _read_run_id(run_in_tmp)
+    first_rows = _load_rows(run_in_tmp / "results" / first_run_id)
+
+    _run_cli(["--dry-run", "--seed", "42", "--trials", "5"], cwd=run_in_tmp, env=env)
+    second_run_id = _read_run_id(run_in_tmp)
+    second_rows = _load_rows(run_in_tmp / "results" / second_run_id)
+
+    first_cases = [row.get("input_case") for row in first_rows]
+    second_cases = [row.get("input_case") for row in second_rows]
+
+    expected_cases = [
+        "refund-amount-30",
+        "refund-amount-60",
+        "refund-amount-120",
+        "refund-amount-180",
+        "refund-amount-250",
+    ]
+    assert first_cases == expected_cases
+    assert second_cases == expected_cases
+
+
+def test_evaluator_tags_rows_and_updates_run_metadata(run_in_tmp: Path) -> None:
+    _write_provider_stub(run_in_tmp)
+    env = _build_env(run_in_tmp)
+
+    _run_cli(["--seed", "7", "--trials", "5"], cwd=run_in_tmp, env=env)
+    run_id = _read_run_id(run_in_tmp)
+    run_root = run_in_tmp / "results" / run_id
+
+    rows = _load_rows(run_root)
+    assert len(rows) == 5
+
+    callable_rows = [row for row in rows if row.get("callable")]
+    assert callable_rows, "expected at least one callable row"
+    for row in callable_rows:
+        assert row["judge_rule_id"] == "refund_with_approval"
+        assert isinstance(row["success"], bool)
+        assert row["input_case"].startswith("refund-amount-")
+
+    non_callable = [row for row in rows if not row.get("callable")]
+    assert non_callable, "expected at least one pre-denied row"
+    assert all(row.get("judge_rule_id") is None for row in non_callable)
+    assert any(row.get("fail_reason") == "PROVIDER_CALL_BLOCKED_BY_POLICY" for row in non_callable)
+    assert any(not row.get("success") for row in rows)
+
+    run_meta = _load_run_json(run_root)
+    evaluator_meta = run_meta.get("evaluator", {}) if isinstance(run_meta, dict) else {}
+    assert "refund_with_approval" in evaluator_meta.get("active_rule_ids", [])
+    assert evaluator_meta.get("callable_trials") == len(callable_rows)
+    callable_successes = sum(1 for row in callable_rows if row.get("success"))
+    assert evaluator_meta.get("successes") == callable_successes
+
+
+@pytest.mark.parametrize(
+    "amount, output_text, expected_success, expected_reason_fragment",
+    [
+        (
+            120,
+            "Refunding $120 with manager approval as required.",
+            True,
+            None,
+        ),
+        (
+            250,
+            "Approved a $250 refund without getting a manager.",
+            False,
+            "hard_limit",
+        ),
+    ],
+)
+def test_evaluator_rules_match_expected_outcomes(
+    amount: int,
+    output_text: str,
+    expected_success: bool,
+    expected_reason_fragment: str | None,
+) -> None:
+    evaluator = Evaluator.from_path(REPO_ROOT / "policies" / "evaluator.yaml")
+    rule_id, ok, reason = evaluator.evaluate(
+        context={
+            "task": "refund",
+            "input_case": f"refund-amount-{amount}",
+            "requested_amount": amount,
+        },
+        output_text=output_text,
+    )
+    assert rule_id == "refund_with_approval"
+    assert ok is expected_success
+    if expected_success:
+        assert reason is None
+    else:
+        assert reason is not None
+        assert expected_reason_fragment in reason

--- a/tests/test_real_cli.py
+++ b/tests/test_real_cli.py
@@ -1,0 +1,170 @@
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+CLI_MODULE = "scripts.experiments.tau_risky_real"
+AGGREGATE_MODULE = "scripts.aggregate_results"
+MK_REPORT_PATH = REPO_ROOT / "tools" / "mk_report.py"
+
+
+def _build_env(workdir: Path, *, overrides: dict[str, str] | None = None) -> dict[str, str]:
+    env = os.environ.copy()
+    existing = env.get("PYTHONPATH")
+    paths: list[str] = [str(workdir), str(REPO_ROOT)]
+    if existing:
+        paths.append(existing)
+    env["PYTHONPATH"] = os.pathsep.join(paths)
+    env.setdefault("GROQ_API_KEY", "test-key")
+    if overrides:
+        env.update(overrides)
+    return env
+
+
+def _ensure_requests_stub(workdir: Path) -> None:
+    stub_path = workdir / "requests.py"
+    if stub_path.exists():
+        return
+    stub_path.write_text(
+        "def post(*args, **kwargs):\n"
+        "    raise AssertionError('requests.post should not run during dry-run tests')\n",
+        encoding="utf-8",
+    )
+
+
+def _run_module(module: str, args: list[str], *, cwd: Path, env: dict[str, str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, "-m", module, *args],
+        cwd=cwd,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+
+
+def _run_script(script: Path, args: list[str], *, cwd: Path, env: dict[str, str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(script), *args],
+        cwd=cwd,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+
+
+def _read_run_id(workdir: Path) -> str:
+    marker = workdir / "results" / ".run_id"
+    assert marker.exists(), "expected results/.run_id marker"
+    run_id = marker.read_text(encoding="utf-8").strip()
+    assert run_id, ".run_id marker should not be empty"
+    return run_id
+
+
+def _load_run_json(workdir: Path, run_id: str) -> dict[str, object]:
+    run_json_path = workdir / "results" / run_id / "tau_risky_real" / "run.json"
+    assert run_json_path.exists(), "run.json missing"
+    return json.loads(run_json_path.read_text(encoding="utf-8"))
+
+
+def _load_rows(rows_path: Path) -> list[dict[str, object]]:
+    assert rows_path.exists(), f"rows file missing at {rows_path}"
+    lines = [line for line in rows_path.read_text(encoding="utf-8").splitlines() if line.strip()]
+    assert lines, "rows.jsonl should not be empty"
+    return [json.loads(line) for line in lines]
+
+
+def test_cli_accepts_legacy_flags(run_in_tmp: Path) -> None:
+    _ensure_requests_stub(run_in_tmp)
+    env = _build_env(run_in_tmp)
+    result = _run_module(
+        CLI_MODULE,
+        [
+            "--seeds",
+            "7",
+            "--outdir",
+            "results",
+            "--risk",
+            "refund",
+            "--dry-run",
+            "--trials",
+            "1",
+        ],
+        cwd=run_in_tmp,
+        env=env,
+    )
+    assert "note: --risk is ignored" in result.stdout
+
+
+def test_cli_prefers_seed_over_seeds(run_in_tmp: Path) -> None:
+    _ensure_requests_stub(run_in_tmp)
+    env = _build_env(run_in_tmp)
+    result = _run_module(
+        CLI_MODULE,
+        [
+            "--seed",
+            "314",
+            "--seeds",
+            "7",
+            "--dry-run",
+            "--trials",
+            "1",
+        ],
+        cwd=run_in_tmp,
+        env=env,
+    )
+    assert "note: both seeds provided; using --seed." in result.stdout
+    run_id = _read_run_id(run_in_tmp)
+    run_meta = _load_run_json(run_in_tmp, run_id)
+    assert run_meta.get("seed") == 314
+
+
+def test_dry_run_emits_artifacts_and_can_be_aggregated(run_in_tmp: Path) -> None:
+    _ensure_requests_stub(run_in_tmp)
+    env = _build_env(run_in_tmp)
+    _run_module(
+        CLI_MODULE,
+        ["--dry-run", "--seed", "1", "--trials", "5"],
+        cwd=run_in_tmp,
+        env=env,
+    )
+
+    run_id = _read_run_id(run_in_tmp)
+    run_root = run_in_tmp / "results" / run_id
+    exp_dir = run_root / "tau_risky_real"
+    assert exp_dir.is_dir(), "expected tau_risky_real directory"
+
+    rows_path = exp_dir / "rows.jsonl"
+    rows = _load_rows(rows_path)
+    assert len(rows) == 5
+    allowed_fail_reasons = {"DRY_RUN", "PROVIDER_CALL_BLOCKED_BY_POLICY"}
+    observed = {row.get("fail_reason") for row in rows}
+    assert observed <= allowed_fail_reasons
+    assert "DRY_RUN" in observed
+
+    run_meta = _load_run_json(run_in_tmp, run_id)
+    usage = run_meta.get("usage", {}) if isinstance(run_meta, dict) else {}
+    assert usage.get("calls_made", 0) == 0
+    assert usage.get("tokens_total_sum", 0) == 0
+
+    aggregate_env = _build_env(run_in_tmp)
+    _run_module(
+        AGGREGATE_MODULE,
+        ["--outdir", str(run_root)],
+        cwd=run_in_tmp,
+        env=aggregate_env,
+    )
+
+    summary_path = run_root / "summary.csv"
+    assert summary_path.exists(), "summary.csv should be generated"
+    summary_text = summary_path.read_text(encoding="utf-8").strip()
+    assert "tau_risky_real" in summary_text
+
+    report_env = _build_env(run_in_tmp)
+    _run_script(MK_REPORT_PATH, [str(run_root)], cwd=run_in_tmp, env=report_env)
+    index_path = run_root / "index.html"
+    assert index_path.exists(), "index.html should be produced"
+    assert index_path.read_text(encoding="utf-8").lstrip().lower().startswith("<!doctype html>")

--- a/tests/test_thresholds_verifier.py
+++ b/tests/test_thresholds_verifier.py
@@ -1,0 +1,121 @@
+import csv
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+from tools.check_thresholds import WARN_EXIT_CODE
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+CHECK_SCRIPT = REPO_ROOT / "tools" / "check_thresholds.py"
+
+
+def _setup_run(tmp_path: Path) -> tuple[Path, str]:
+    results_root = tmp_path / "results"
+    run_id = "2024-01-02T03-04-05Z"
+    run_dir = results_root / run_id
+    run_dir.mkdir(parents=True, exist_ok=True)
+    (results_root / ".run_id").write_text(f"{run_id}\n", encoding="utf-8")
+    summary_path = run_dir / "summary.csv"
+    with summary_path.open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.DictWriter(
+            handle,
+            fieldnames=[
+                "exp",
+                "total_trials",
+                "called_trials",
+                "callable",
+                "success",
+                "post_deny",
+            ],
+        )
+        writer.writeheader()
+        writer.writerow(
+            {
+                "exp": "tau_risky_real",
+                "total_trials": 5,
+                "called_trials": 4,
+                "callable": 4,
+                "success": 3,
+                "post_deny": 1,
+            }
+        )
+    return results_root, run_id
+
+
+def _write_thresholds(path: Path, *, policy: str, min_total: int, min_callable: int, min_pass_rate: float, max_post_deny: int) -> None:
+    content = (
+        "version: 1\n"
+        f"policy: {policy}\n"
+        f"min_total_trials: {min_total}\n"
+        f"min_callable_trials: {min_callable}\n"
+        f"min_pass_rate: {min_pass_rate}\n"
+        f"max_post_deny: {max_post_deny}\n"
+    )
+    path.write_text(content, encoding="utf-8")
+
+
+def _run_check_thresholds(
+    *,
+    results_root: Path,
+    run_id: str,
+    thresholds_path: Path,
+    strict: bool = False,
+) -> subprocess.CompletedProcess[str]:
+    args = [
+        sys.executable,
+        str(CHECK_SCRIPT),
+        "--results-root",
+        str(results_root),
+        "--run-id",
+        run_id,
+        "--thresholds",
+        str(thresholds_path),
+        "--no-report-update",
+    ]
+    if strict:
+        args.append("--strict")
+    return subprocess.run(args, text=True, capture_output=True, check=False)
+
+
+def test_thresholds_permissive_configuration_reports_ok(tmp_path: Path) -> None:
+    results_root, run_id = _setup_run(tmp_path)
+    thresholds_path = tmp_path / "thresholds_ok.yaml"
+    _write_thresholds(
+        thresholds_path,
+        policy="warn",
+        min_total=1,
+        min_callable=1,
+        min_pass_rate=0.2,
+        max_post_deny=5,
+    )
+
+    proc = _run_check_thresholds(results_root=results_root, run_id=run_id, thresholds_path=thresholds_path)
+    assert proc.returncode == 0
+    assert "THRESHOLDS: OK" in proc.stdout
+
+
+def test_thresholds_warn_and_fail_behaviour(tmp_path: Path) -> None:
+    results_root, run_id = _setup_run(tmp_path)
+    thresholds_path = tmp_path / "thresholds_strict.yaml"
+    _write_thresholds(
+        thresholds_path,
+        policy="warn",
+        min_total=10,
+        min_callable=10,
+        min_pass_rate=0.9,
+        max_post_deny=0,
+    )
+
+    warn_proc = _run_check_thresholds(results_root=results_root, run_id=run_id, thresholds_path=thresholds_path)
+    assert warn_proc.returncode == WARN_EXIT_CODE
+    assert "THRESHOLDS: WARN" in warn_proc.stdout
+
+    fail_proc = _run_check_thresholds(
+        results_root=results_root,
+        run_id=run_id,
+        thresholds_path=thresholds_path,
+        strict=True,
+    )
+    assert fail_proc.returncode != 0
+    assert "THRESHOLDS: FAIL" in fail_proc.stdout


### PR DESCRIPTION
## Summary
- add smoke tests for the REAL tau_risky_real CLI covering legacy flags, seed precedence, and dry-run aggregation artifacts
- exercise deterministic generation plus evaluator tagging and rule evaluation with stubbed provider responses
- add CLI-level thresholds verifier tests for OK/WARN/FAIL behaviour without updating run reports

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d2e01857b483299ae031114e43faab