### PR TITLE
Add make mvp entrypoint and open-report helper

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,7 @@
-# Copy to ".env" locally (never commit .env).
-# In CI, use repository Secrets instead.
-GROQ_API_KEY=put_key_here
-GEMINI_API_KEY=put_key_here
+# Copy to .env and edit as needed
+GROQ_API_KEY=__put_your_key_here__
+MODEL=llama-3.1-8b-instant
+TRIALS=3
+SEED=42
+# Set to 1 for no-provider dry run; 0 for real calls (requires key)
+DRY_RUN=1

--- a/README.md
+++ b/README.md
@@ -42,21 +42,10 @@
 ## Quickstart
 ```bash
 pip install -r requirements-ci.txt   # or: make install
-
-# 1) Set provider secret
-export GROQ_API_KEY=...
-
-# 2) Run the REAL slice locally (cheap default)
-python -m scripts.experiments.tau_risky_real --trials 6 --seed 42
-
-# 3) Build report
-make report   # or: python -m scripts.aggregate_results --run_id <RUN_ID>
-
-
-Artifacts appear under:
-
-results/<RUN_ID>/tau_risky_real/{rows.jsonl,run.json}
-results/LATEST/{summary.csv,summary.svg,index.html}
+cp .env.example .env                 # edit to add GROQ_API_KEY for real calls
+make mvp                             # translator → run → aggregate (dry run by default)
+make open-report                     # opens results/LATEST/index.html
+# Real provider calls: set DRY_RUN=0 in .env or run `DRY_RUN=0 make mvp`
 ```
 
 ## Why this exists
@@ -153,9 +142,11 @@ Run `make check-thresholds` locally (`STRICT=1 make check-thresholds` to fail). 
 
 ## Make targets (TL;DR)
 - `make help` — list common targets & docs.
+- `make mvp` — end-to-end translator → REAL slice → aggregate (dry-run by default).
 - `make demo` — tiny sweep (defaults to SHIM) producing `results/<RUN_ID>/`.
 - `make xsweep CONFIG=...` — run a configurable sweep.
 - `make report` — asserts `summary.csv`/`summary.svg`; updates `results/LATEST`.
+- `make open-report` — open or print `results/LATEST/index.html`.
 - `make latest` — refreshes `results/LATEST` to the newest valid run.
 - `make open-artifacts` — opens `results/LATEST/summary.svg` and `summary.csv`.
 - `make list-runs` — list timestamped run folders with quick validity flags.

--- a/tools/open_report.py
+++ b/tools/open_report.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""Open or print the latest DoomArena-Lab HTML report."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+import webbrowser
+from pathlib import Path
+
+
+def _as_bool(value: str | None) -> bool:
+    if value is None:
+        return False
+    return value.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _resolve_pointer(path: Path) -> Path:
+    resolved = path.resolve()
+    if resolved.exists():
+        return resolved
+    pointer = path.parent / f"{path.name}.path"
+    if pointer.exists():
+        target_text = pointer.read_text(encoding="utf-8").strip()
+        if target_text:
+            target = Path(target_text)
+            if target.exists():
+                try:
+                    return target.resolve()
+                except Exception:
+                    return target
+    return resolved
+
+
+def _resolve_index(target: Path) -> Path:
+    if target.is_dir():
+        run_dir = _resolve_pointer(target)
+        return run_dir / "index.html"
+    if target.suffix.lower() == ".html":
+        if target.exists():
+            return target.resolve()
+        run_dir = _resolve_pointer(target.parent)
+        return run_dir / target.name
+    run_dir = _resolve_pointer(target)
+    return run_dir / "index.html"
+
+
+def open_report(path: Path, *, print_only: bool) -> int:
+    index_path = _resolve_index(path)
+    if not index_path.exists():
+        print(f"No report found at {index_path}", file=sys.stderr)
+        return 1
+    try:
+        absolute = index_path.resolve()
+    except Exception:
+        absolute = index_path.absolute()
+    print(absolute)
+    if print_only:
+        return 0
+    try:
+        opened = webbrowser.open(absolute.as_uri(), new=0, autoraise=True)
+    except Exception as exc:
+        print(f"WARNING: failed to open browser: {exc}", file=sys.stderr)
+        return 0
+    if not opened:
+        print("NOTE: browser open returned False; path printed above.", file=sys.stderr)
+    return 0
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(description="Open the latest HTML report in a browser")
+    parser.add_argument(
+        "target",
+        nargs="?",
+        default="results/LATEST",
+        help="Report directory or index.html path (default: results/LATEST)",
+    )
+    args = parser.parse_args(argv)
+    target_path = Path(args.target).expanduser()
+    print_only = _as_bool(os.getenv("CI")) or _as_bool(os.getenv("MVP_PRINT_ONLY"))
+    return open_report(target_path, print_only=print_only)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))


### PR DESCRIPTION
## Summary
- add a `make mvp` target that loads `.env`, runs the REAL slice with safe defaults, aggregates artifacts, refreshes `results/LATEST`, and prints a short summary
- ship a `.env.example` plus README updates so the new flow is discoverable
- provide a `make open-report` target backed by `tools/open_report.py` to open or print the latest HTML report

## Testing
- make mvp
- make open-report

------
https://chatgpt.com/codex/tasks/task_e_68d2e851ef808329b12499d18bee9db1