### PR TITLE
report(exp-010): add status banner, callable/pass panels, reason breakdown, and data links to index.html (no behavior changes)

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,12 @@ The GitHub Action exposes the same inputs (`max_trails`/`max_trials`, `max_total
   - Per-experiment folders (e.g., `tau_risky_real/rows.jsonl`)
 - Optional **thresholds** in `thresholds.yaml` (run-level mins/maxes + policy) drive CI status after aggregation.
 
+### Reading the report
+- The top status pill repeats the thresholds verdict (OK/WARN/FAIL) so you can spot run health immediately.
+- Quick cards show total vs callable trials, passes, and pass-rate (computed over callable trials).
+- Top reason cards surface the most common allow/warn/deny reason codes for fast gate triage.
+- Download links for `summary.csv` and the `rows.jsonl` files live near the top of `index.html`.
+
 ### Thresholds & CI status
 `tools/check_thresholds.py` reads run metrics + `thresholds.yaml` and prints an `OK/WARN/FAIL` line:
 


### PR DESCRIPTION
## Summary
- surface the thresholds verdict in the report header as a color-coded status pill
- add quick trial/pass cards, prominent data download links, and the reason-code breakdown by gate decision
- expose per-decision reason counts from the aggregator so the HTML renderer can reuse existing tallies

## Testing
- pytest tests/test_lib.py -q
- python -m compileall tools/mk_report.py scripts/aggregate_results.py

------
https://chatgpt.com/codex/tasks/task_e_68d2f30698448329a95f103bcc939d36