### PR TITLE
EXP-012: add config schemas + CI preflight validation

### DIFF
--- a/.github/workflows/run-demo.yml
+++ b/.github/workflows/run-demo.yml
@@ -39,6 +39,15 @@ jobs:
         shell: bash
         run: make install
 
+      - name: Pre-flight config validation
+        shell: bash
+        run: |
+          PYBIN=".venv/bin/python"
+          if [ ! -x "$PYBIN" ]; then
+            PYBIN="python"
+          fi
+          "$PYBIN" tools/ci_preflight.py
+
       - name: Run demo (single RUN_ID with both experiments)
         env:
           TRIALS: ${{ inputs.trials }}

--- a/.github/workflows/run-real-mvp.yml
+++ b/.github/workflows/run-real-mvp.yml
@@ -71,12 +71,12 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install -r requirements-ci.txt
 
+      - name: Pre-flight config validation
+        run: python tools/ci_preflight.py
+
       - name: Set RUN_ID
         shell: bash
         run: echo "RUN_ID=$(date -u +'%Y-%m-%dT%H-%M-%SZ')" >> $GITHUB_ENV
-
-      - name: Pre-flight checks (imports only)
-        run: python tools/ci_preflight.py
 
       - name: Show Python and dep versions
         shell: bash

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@
 #   RUN_ID  ?= (timestamp default)     # results/<RUN_ID>; persisted via results/.run_id
 # ------------------------------------------------------------------------------
 
-.PHONY: venv install test run sweep aggregate report scaffold check-schema plot notes sweep3 real1 xrun xsweep xsweep-all topn demo test-unit ci latest tidy-run open-artifacts open-report list-runs journal install-tau help vars check-thresholds mvp
+.PHONY: venv install test run sweep aggregate report scaffold check-schema plot notes sweep3 real1 xrun xsweep xsweep-all topn demo test-unit ci latest tidy-run open-artifacts open-report list-runs journal install-tau help vars check-thresholds mvp validate
 
 SHELL := /bin/bash
 
@@ -68,7 +68,7 @@ venv: ## Create local virtualenv in .venv
 	$(PY) -m pip install -U pip
 
 install: venv ## Install runtime + dev deps into .venv
-	$(PIP) install -U doomarena doomarena-taubench pytest pyyaml pandas matplotlib
+	$(PIP) install -U doomarena doomarena-taubench pytest pyyaml jsonschema pandas matplotlib
 	$(PY) scripts/ensure_tau_bench.py || (echo "tau_bench unavailable; continuing without real τ-Bench" && exit 0)
 
 check-schema: venv
@@ -382,3 +382,7 @@ vars: ## Print effective overridable variables
 	echo "MODE=$(MODE)"; \
 	echo "RUN_ID=$(RUN_ID)"; \
 	echo "RESULTS_DIR=$(RESULTS_DIR)"
+validate: ## Validate configuration files (YAML → JSON Schema)
+	@if [ -x "$(PY)" ]; then PYBIN="$(PY)"; else PYBIN="$(PYTHON)"; fi; \
+	"$$PYBIN" tools/ci_preflight.py
+

--- a/README.md
+++ b/README.md
@@ -49,6 +49,11 @@ make open-report                     # opens results/LATEST/index.html
 # Real provider calls: set DRY_RUN=0 in .env or run `DRY_RUN=0 make mvp`
 ```
 
+## Validate configs
+- `make validate` (or `python tools/ci_preflight.py`) checks configs against the JSON Schemas in [`schemas/`](schemas/).
+- It validates `thresholds.yaml`, `specs/threat_model.yaml`, `policies/evaluator.yaml`, and `policies/gates.yaml`; missing optional files print `not found (skipped)`.
+- Error messages include JSONPath-style pointers (e.g. `$.rules[0].id`) so you can jump straight to the failing field.
+
 ## Why this exists
 - Enable **fast iteration** with **CI-friendly artifacts** you can attach to PRs.
 - Provide **SHIM** simulation adapters for deterministic demos and a **REAL** path to cloud models.

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -2,6 +2,7 @@ doomarena
 doomarena-taubench
 pytest
 pyyaml
+jsonschema>=4.22,<5.0
 requests>=2.31,<3.0
 numpy>=1.26.4,<2.0
 pandas>=2.2.2,<2.3

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,7 @@
 # Dev/test deps (keep light; match Makefile install)
 pytest
 pyyaml
+jsonschema>=4.22,<5.0
 requests>=2.31,<3.0
 numpy>=1.26.4,<2.0
 pandas>=2.2.2,<2.3

--- a/schemas/evaluator.schema.json
+++ b/schemas/evaluator.schema.json
@@ -1,0 +1,218 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://doomarena.dev/schemas/evaluator.schema.json",
+  "title": "Evaluator policy",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "version",
+    "rules"
+  ],
+  "properties": {
+    "version": {
+      "type": "integer",
+      "const": 1,
+      "description": "Schema version"
+    },
+    "rules": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/$defs/rule"
+      }
+    }
+  },
+  "$defs": {
+    "nonEmptyString": {
+      "type": "string",
+      "minLength": 1
+    },
+    "stringOrStringArray": {
+      "oneOf": [
+        {
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/$defs/nonEmptyString"
+          }
+        }
+      ]
+    },
+    "simpleValue": {
+      "oneOf": [
+        {
+          "type": ["string", "number", "integer", "boolean"]
+        },
+        {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": ["string", "number", "integer", "boolean"]
+          }
+        }
+      ]
+    },
+    "condition": {
+      "oneOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": ["string", "number", "integer"]
+        },
+        {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/$defs/condition"
+          }
+        },
+        {
+          "type": "object",
+          "minProperties": 1,
+          "properties": {
+            "all": {
+              "type": "array",
+              "minItems": 1,
+              "items": {
+                "$ref": "#/$defs/condition"
+              }
+            },
+            "any": {
+              "type": "array",
+              "minItems": 1,
+              "items": {
+                "$ref": "#/$defs/condition"
+              }
+            },
+            "not": {
+              "$ref": "#/$defs/condition"
+            },
+            "field": {
+              "$ref": "#/$defs/nonEmptyString"
+            },
+            "op": {
+              "$ref": "#/$defs/nonEmptyString"
+            },
+            "value": {},
+            "value_from": {
+              "$ref": "#/$defs/nonEmptyString"
+            },
+            "context": {
+              "$ref": "#/$defs/nonEmptyString"
+            },
+            "one_of": {
+              "type": "array",
+              "minItems": 1,
+              "items": {
+                "$ref": "#/$defs/simpleValue"
+              }
+            },
+            "text_contains": {
+              "$ref": "#/$defs/stringOrStringArray"
+            },
+            "text_not_contains": {
+              "$ref": "#/$defs/stringOrStringArray"
+            },
+            "text_regex": {
+              "$ref": "#/$defs/nonEmptyString"
+            },
+            "regex": {
+              "$ref": "#/$defs/nonEmptyString"
+            },
+            "reason_code": {
+              "$ref": "#/$defs/nonEmptyString"
+            },
+            "message": {
+              "$ref": "#/$defs/nonEmptyString"
+            }
+          },
+          "patternProperties": {
+            "^(?!(all|any|not|field|op|value|value_from|context|one_of|text_contains|text_not_contains|text_regex|regex|reason_code|message)$)[A-Za-z0-9_.-]+$": {
+              "$ref": "#/$defs/simpleValue"
+            }
+          },
+          "additionalProperties": false
+        }
+      ]
+    },
+    "amountRule": {
+      "oneOf": [
+        {
+          "type": ["number", "integer"]
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "limit": {
+              "type": ["number", "integer"]
+            },
+            "limit_reason": {
+              "$ref": "#/$defs/nonEmptyString"
+            },
+            "approval_threshold": {
+              "type": ["number", "integer"]
+            },
+            "approval_terms": {
+              "oneOf": [
+                {
+                  "$ref": "#/$defs/nonEmptyString"
+                },
+                {
+                  "type": "array",
+                  "minItems": 1,
+                  "items": {
+                    "$ref": "#/$defs/nonEmptyString"
+                  }
+                }
+              ]
+            },
+            "approval_reason": {
+              "$ref": "#/$defs/nonEmptyString"
+            }
+          }
+        }
+      ]
+    },
+    "rule": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "applies_if",
+        "success_if"
+      ],
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "applies_if": {
+          "$ref": "#/$defs/condition"
+        },
+        "success_if": {
+          "type": "object",
+          "additionalProperties": false,
+          "minProperties": 1,
+          "properties": {
+            "contains_any": {
+              "$ref": "#/$defs/stringOrStringArray"
+            },
+            "forbids_any": {
+              "$ref": "#/$defs/stringOrStringArray"
+            },
+            "denies_if_amount_gt": {
+              "$ref": "#/$defs/amountRule"
+            },
+            "requires_approval_if_amount_gt": {
+              "$ref": "#/$defs/amountRule"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/schemas/gates.schema.json
+++ b/schemas/gates.schema.json
@@ -1,0 +1,286 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://doomarena.dev/schemas/gates.schema.json",
+  "title": "Governance gates policy",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "version"
+  ],
+  "properties": {
+    "version": {
+      "type": "integer",
+      "const": 1,
+      "description": "Schema version"
+    },
+    "defaults": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "mode": {
+          "type": "string",
+          "enum": [
+            "allow",
+            "warn",
+            "deny",
+            "strict"
+          ]
+        }
+      }
+    },
+    "limits": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "max_calls": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "max_trials": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "max_total_tokens": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "max_prompt_tokens": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "max_completion_tokens": {
+          "type": "integer",
+          "minimum": 0
+        }
+      }
+    },
+    "pre_call": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/rule"
+      }
+    },
+    "post_call": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/rule"
+      }
+    }
+  },
+  "$defs": {
+    "nonEmptyString": {
+      "type": "string",
+      "minLength": 1
+    },
+    "reasonMessage": {
+      "oneOf": [
+        {
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "allow": {
+              "$ref": "#/$defs/nonEmptyString"
+            },
+            "warn": {
+              "$ref": "#/$defs/nonEmptyString"
+            },
+            "deny": {
+              "$ref": "#/$defs/nonEmptyString"
+            }
+          }
+        }
+      ]
+    },
+    "simpleValue": {
+      "oneOf": [
+        {
+          "type": ["string", "number", "integer", "boolean"]
+        },
+        {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": ["string", "number", "integer", "boolean"]
+          }
+        }
+      ]
+    },
+    "stringGroup": {
+      "oneOf": [
+        {
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/$defs/nonEmptyString"
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "minProperties": 1,
+          "properties": {
+            "any": {
+              "type": "array",
+              "minItems": 1,
+              "items": {
+                "$ref": "#/$defs/nonEmptyString"
+              }
+            },
+            "all": {
+              "type": "array",
+              "minItems": 1,
+              "items": {
+                "$ref": "#/$defs/nonEmptyString"
+              }
+            }
+          }
+        }
+      ]
+    },
+    "condition": {
+      "oneOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": ["string", "number", "integer"]
+        },
+        {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/$defs/condition"
+          }
+        },
+        {
+          "type": "object",
+          "minProperties": 1,
+          "properties": {
+            "all": {
+              "type": "array",
+              "minItems": 1,
+              "items": {
+                "$ref": "#/$defs/condition"
+              }
+            },
+            "any": {
+              "type": "array",
+              "minItems": 1,
+              "items": {
+                "$ref": "#/$defs/condition"
+              }
+            },
+            "not": {
+              "$ref": "#/$defs/condition"
+            },
+            "field": {
+              "$ref": "#/$defs/nonEmptyString"
+            },
+            "op": {
+              "$ref": "#/$defs/nonEmptyString"
+            },
+            "value": {},
+            "value_from": {
+              "$ref": "#/$defs/nonEmptyString"
+            },
+            "context": {
+              "$ref": "#/$defs/nonEmptyString"
+            },
+            "one_of": {
+              "type": "array",
+              "minItems": 1,
+              "items": {
+                "$ref": "#/$defs/simpleValue"
+              }
+            },
+            "text_contains": {
+              "$ref": "#/$defs/stringGroup"
+            },
+            "text_not_contains": {
+              "$ref": "#/$defs/stringGroup"
+            },
+            "text_regex": {
+              "$ref": "#/$defs/nonEmptyString"
+            },
+            "regex": {
+              "$ref": "#/$defs/nonEmptyString"
+            },
+            "reason_code": {
+              "$ref": "#/$defs/nonEmptyString"
+            },
+            "message": {
+              "$ref": "#/$defs/nonEmptyString"
+            }
+          },
+          "patternProperties": {
+            "^(?!(all|any|not|field|op|value|value_from|context|one_of|text_contains|text_not_contains|text_regex|regex|reason_code|message|condition)$)[A-Za-z0-9_.-]+$": {
+              "$ref": "#/$defs/simpleValue"
+            }
+          },
+          "additionalProperties": false
+        }
+      ]
+    },
+    "action": {
+      "oneOf": [
+        {
+          "$ref": "#/$defs/condition"
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "condition"
+          ],
+          "properties": {
+            "condition": {
+              "$ref": "#/$defs/condition"
+            },
+            "reason_code": {
+              "$ref": "#/$defs/nonEmptyString"
+            },
+            "message": {
+              "$ref": "#/$defs/nonEmptyString"
+            }
+          }
+        }
+      ]
+    },
+    "rule": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id"
+      ],
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "applies_if": {
+          "$ref": "#/$defs/condition"
+        },
+        "deny_if": {
+          "$ref": "#/$defs/action"
+        },
+        "warn_if": {
+          "$ref": "#/$defs/action"
+        },
+        "allow_if": {
+          "$ref": "#/$defs/action"
+        },
+        "reason_code": {
+          "$ref": "#/$defs/reasonMessage"
+        },
+        "message": {
+          "$ref": "#/$defs/reasonMessage"
+        }
+      }
+    }
+  }
+}

--- a/schemas/threat_model.schema.json
+++ b/schemas/threat_model.schema.json
@@ -1,0 +1,61 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://doomarena.dev/schemas/threat_model.schema.json",
+  "title": "Threat model specification",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "version",
+    "slices"
+  ],
+  "properties": {
+    "version": {
+      "type": "integer",
+      "const": 1,
+      "description": "Schema version"
+    },
+    "slices": {
+      "type": "array",
+      "minItems": 1,
+      "description": "Collection of risky slices to evaluate",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "task",
+          "personas",
+          "amounts"
+        ],
+        "properties": {
+          "task": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Task identifier (e.g. refund)"
+          },
+          "personas": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "type": "string",
+              "minLength": 1
+            },
+            "description": "Personas included in the slice"
+          },
+          "amounts": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "type": "number"
+            },
+            "description": "Representative numeric amounts"
+          },
+          "metadata": {
+            "type": "object",
+            "description": "Optional free-form metadata",
+            "additionalProperties": true
+          }
+        }
+      }
+    }
+  }
+}

--- a/schemas/thresholds.schema.json
+++ b/schemas/thresholds.schema.json
@@ -1,0 +1,54 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://doomarena.dev/schemas/thresholds.schema.json",
+  "title": "Threshold configuration",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "version",
+    "min_total_trials",
+    "min_callable_trials",
+    "min_pass_rate"
+  ],
+  "properties": {
+    "version": {
+      "type": "integer",
+      "const": 1,
+      "description": "Schema version"
+    },
+    "min_total_trials": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Minimum total number of trials required for a run"
+    },
+    "min_callable_trials": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Minimum number of callable trials required for a run"
+    },
+    "min_pass_rate": {
+      "type": "number",
+      "minimum": 0,
+      "maximum": 1,
+      "description": "Minimum acceptable pass rate (0-1 inclusive)"
+    },
+    "max_post_deny": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Maximum number of post-call denies allowed"
+    },
+    "policy": {
+      "type": "string",
+      "enum": [
+        "allow",
+        "warn",
+        "strict"
+      ],
+      "description": "How to treat threshold violations"
+    },
+    "notes": {
+      "type": "string",
+      "description": "Free-form notes about the threshold policy"
+    }
+  }
+}

--- a/tools/ci_preflight.py
+++ b/tools/ci_preflight.py
@@ -1,95 +1,323 @@
 #!/usr/bin/env python3
-"""Self-healing preflight import checker for CI workflows."""
+"""Validate configuration files before CI workflows run."""
 
 from __future__ import annotations
 
-import importlib
-import subprocess
+import json
+import os
+import re
 import sys
+from dataclasses import dataclass
 from pathlib import Path
-from typing import Dict, Tuple
+from typing import Callable, Dict, List, Mapping, MutableMapping, Sequence, Tuple
+
+
+try:  # pragma: no cover - import guard for local executions without deps
+    import yaml
+except Exception as exc:  # noqa: BLE001 - surface the original exception text
+    print(f"ERROR tools/ci_preflight.py requires PyYAML: {exc}")
+    sys.exit(1)
+
+try:  # pragma: no cover - import guard for local executions without deps
+    from jsonschema import Draft202012Validator, exceptions as jsonschema_exceptions
+except Exception as exc:  # noqa: BLE001 - surface the original exception text
+    print(f"ERROR tools/ci_preflight.py requires jsonschema: {exc}")
+    sys.exit(1)
 
 
 SCRIPT_DIR = Path(__file__).resolve().parent
 REPO_ROOT = SCRIPT_DIR.parent
 
-# Ensure the repository root is the first entry on sys.path so third-party
-# imports (notably numpy) resolve their compiled extensions correctly when this
-# script is executed via ``python tools/ci_preflight.py``.
-if sys.path and Path(sys.path[0]).resolve() == SCRIPT_DIR:
-    sys.path.pop(0)
-    sys.path.insert(0, str(REPO_ROOT))
-elif str(REPO_ROOT) not in sys.path:
-    sys.path.insert(0, str(REPO_ROOT))
+
+@dataclass(frozen=True)
+class ConfigSpec:
+    """Configuration document wired into preflight validation."""
+
+    relative_path: str
+    schema_filename: str
+
+    @property
+    def path(self) -> Path:
+        return REPO_ROOT / self.relative_path
+
+    @property
+    def schema_path(self) -> Path:
+        return REPO_ROOT / self.schema_filename
 
 
-REQUIRED_MODULES = ("numpy", "pandas", "matplotlib")
+@dataclass(frozen=True)
+class Violation:
+    path: Tuple[object, ...]
+    message: str
 
 
-def import_required_modules() -> Tuple[Dict[str, object], Dict[str, BaseException]]:
-    """Attempt to import required modules.
+CONFIG_SPECS: Tuple[ConfigSpec, ...] = (
+    ConfigSpec("thresholds.yaml", "schemas/thresholds.schema.json"),
+    ConfigSpec("specs/threat_model.yaml", "schemas/threat_model.schema.json"),
+    ConfigSpec("policies/evaluator.yaml", "schemas/evaluator.schema.json"),
+    ConfigSpec("policies/gates.yaml", "schemas/gates.schema.json"),
+)
 
-    Returns a tuple of (loaded_modules, missing_modules).
-    """
-
-    loaded = {}
-    missing = {}
-    for name in REQUIRED_MODULES:
-        try:
-            loaded[name] = importlib.import_module(name)
-        except Exception as exc:  # noqa: BLE001 - we want the original exception message.
-            missing[name] = exc
-    return loaded, missing
+REAL_REQUIRED: Tuple[str, ...] = (
+    "thresholds.yaml",
+    "policies/evaluator.yaml",
+)
 
 
-def install_requirements() -> None:
-    """Install CI requirements using the current interpreter."""
+def load_schema(path: Path) -> Draft202012Validator:
+    try:
+        schema = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError as exc:  # pragma: no cover - schema missing is fatal
+        raise SystemExit(f"ERROR schema file not found: {path}") from exc
+    except json.JSONDecodeError as exc:
+        raise SystemExit(f"ERROR invalid JSON schema at {path}: {exc}") from exc
+    try:
+        return Draft202012Validator(schema)
+    except jsonschema_exceptions.SchemaError as exc:  # pragma: no cover - developer error
+        raise SystemExit(f"ERROR schema at {path} is invalid: {exc}") from exc
 
-    repo_root = Path(__file__).resolve().parent.parent
-    requirements_file = repo_root / "requirements-ci.txt"
-    if not requirements_file.is_file():
-        raise FileNotFoundError(f"requirements file not found: {requirements_file}")
 
-    print(f"Attempting to install dependencies from {requirements_file}...")
-    subprocess.run(
-        [sys.executable, "-m", "pip", "install", "-r", str(requirements_file)],
-        check=True,
-    )
+def detect_context() -> str:
+    override = os.getenv("CI_PREFLIGHT_MODE")
+    if override:
+        text = override.strip().lower()
+        if text in {"real", "strict"}:
+            return "real"
+        if text in {"pr", "dry-run", "dryrun"}:
+            return "pr"
+        return text
+
+    event = os.getenv("GITHUB_EVENT_NAME", "").strip().lower()
+    if event == "pull_request":
+        return "pr"
+    if event == "workflow_dispatch":
+        return "workflow_dispatch"
+    if event == "push":
+        ref = os.getenv("GITHUB_REF", "").strip().lower()
+        if ref == "refs/heads/main":
+            return "main"
+        return "push"
+    return "local"
+
+
+def required_files(context: str) -> Tuple[str, ...]:
+    override = os.getenv("CI_PREFLIGHT_REQUIRED")
+    if override:
+        tokens = [token.strip() for token in re.split(r"[,\s]+", override) if token.strip()]
+        return tuple(tokens)
+
+    if context in {"real", "workflow_dispatch", "main"}:
+        return REAL_REQUIRED
+    return tuple()
+
+
+def load_yaml_document(path: Path) -> object:
+    try:
+        text = path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        raise
+    except OSError as exc:
+        raise RuntimeError(f"failed to read file: {exc}") from exc
+
+    try:
+        return yaml.safe_load(text)
+    except yaml.YAMLError as exc:
+        raise RuntimeError(f"invalid YAML: {exc}") from exc
+
+
+def describe_error(error: jsonschema_exceptions.ValidationError) -> Tuple[Tuple[object, ...], str]:
+    path_parts: List[object] = list(error.absolute_path)
+    validator = error.validator
+    value = error.validator_value
+    instance = error.instance
+
+    if validator == "required":
+        missing = _extract_quoted_token(error.message)
+        if missing:
+            path_parts.append(missing)
+        return tuple(path_parts), f"missing required property '{missing or ''}'".rstrip()
+
+    if validator == "additionalProperties":
+        unexpected = _extract_quoted_token(error.message)
+        if unexpected:
+            path_parts.append(unexpected)
+        message = unexpected and f"unexpected property '{unexpected}'" or error.message
+        return tuple(path_parts), message
+
+    if validator == "type":
+        expected = _format_expected_type(value)
+        actual = type(instance).__name__
+        return tuple(path_parts), f"expected type {expected} (found {actual})"
+
+    if validator == "enum":
+        allowed = ", ".join(str(item) for item in value)
+        return tuple(path_parts), f"must be one of {{{allowed}}} (found {instance!r})"
+
+    if validator == "const":
+        return tuple(path_parts), f"must equal {value!r} (found {instance!r})"
+
+    if validator == "minimum":
+        return tuple(path_parts), f"must be >= {value} (found {instance})"
+
+    if validator == "maximum":
+        return tuple(path_parts), f"must be <= {value} (found {instance})"
+
+    if validator == "minItems":
+        length = len(instance) if hasattr(instance, "__len__") else "unknown"
+        return tuple(path_parts), f"must contain at least {value} items (found {length})"
+
+    if validator == "minLength":
+        length = len(instance) if isinstance(instance, str) else "unknown"
+        return tuple(path_parts), f"must be at least {value} characters (found {length})"
+
+    if validator == "minProperties":
+        length = len(instance) if isinstance(instance, MutableMapping) else "unknown"
+        return tuple(path_parts), f"must define at least {value} properties (found {length})"
+
+    return tuple(path_parts), error.message
+
+
+def _format_expected_type(value: object) -> str:
+    if isinstance(value, list):
+        return " or ".join(sorted(str(item) for item in value))
+    return str(value)
+
+
+def _extract_quoted_token(message: str) -> str | None:
+    match = re.search(r"'([^']+)'", message)
+    if match:
+        return match.group(1)
+    return None
+
+
+def format_path(parts: Sequence[object]) -> str:
+    if not parts:
+        return "$"
+    path = "$"
+    for part in parts:
+        if isinstance(part, int):
+            path += f"[{part}]"
+            continue
+        token = str(part)
+        if token.isidentifier():
+            path += f".{token}"
+        else:
+            path += f"[{json.dumps(token)}]"
+    return path
+
+
+def sort_key(error: jsonschema_exceptions.ValidationError) -> Tuple[Tuple[int, str], ...]:
+    key: List[Tuple[int, str]] = []
+    for part in error.absolute_path:
+        if isinstance(part, int):
+            key.append((1, f"{part:08d}"))
+        else:
+            key.append((0, str(part)))
+    return tuple(key)
+
+
+def _check_unique_rule_ids(data: object) -> List[Violation]:
+    violations: List[Violation] = []
+    if not isinstance(data, Mapping):
+        return violations
+    rules = data.get("rules")
+    if not isinstance(rules, list):
+        return violations
+    seen: Dict[str, int] = {}
+    for idx, entry in enumerate(rules):
+        if not isinstance(entry, Mapping):
+            continue
+        rule_id = entry.get("id")
+        if not isinstance(rule_id, str):
+            continue
+        token = rule_id.strip()
+        if not token:
+            continue
+        if token in seen:
+            first_idx = seen[token]
+            message = f"duplicate rule id '{token}' (first seen at rules[{first_idx}].id)"
+            violations.append(Violation(("rules", idx, "id"), message))
+        else:
+            seen[token] = idx
+    return violations
+
+
+EXTRA_CHECKS: Mapping[str, Tuple[Callable[[object], List[Violation]], ...]] = {
+    "policies/evaluator.yaml": (_check_unique_rule_ids,),
+}
+
+
+def run_extra_checks(spec: ConfigSpec, data: object) -> List[Violation]:
+    callbacks = EXTRA_CHECKS.get(spec.relative_path)
+    if not callbacks:
+        return []
+    results: List[Violation] = []
+    for callback in callbacks:
+        results.extend(callback(data))
+    return results
+
+
+def validate_spec(spec: ConfigSpec, validator: Draft202012Validator, *, required: bool) -> List[Violation]:
+    rel_path = spec.relative_path
+    path = spec.path
+    if not path.exists():
+        if required:
+            message = "required file not found for REAL runs"
+            print(f"ERROR {rel_path} $: {message}")
+            return [Violation(tuple(), message)]
+        print(f"SKIP {rel_path} not found (skipped)")
+        return []
+
+    try:
+        data = load_yaml_document(path)
+    except FileNotFoundError:
+        message = "required file not found"
+        print(f"ERROR {rel_path} $: {message}")
+        return [Violation(tuple(), message)]
+    except RuntimeError as exc:
+        text = str(exc)
+        print(f"ERROR {rel_path} $: {text}")
+        return [Violation(tuple(), text)]
+
+    errors = sorted(validator.iter_errors(data), key=sort_key)
+    violations = [Violation(*describe_error(error)) for error in errors]
+    violations.extend(run_extra_checks(spec, data))
+
+    if violations:
+        for violation in violations:
+            print(f"ERROR {rel_path} {format_path(violation.path)}: {violation.message}")
+        return violations
+
+    print(f"OK {rel_path}")
+    return []
 
 
 def main() -> int:
-    loaded, missing = import_required_modules()
+    context = detect_context()
+    required = set(required_files(context))
 
-    if missing:
-        print("Initial import check failed; missing modules detected:")
-        for name, err in missing.items():
-            print(f"  - {name}: {err}")
-        try:
-            install_requirements()
-        except subprocess.CalledProcessError as exc:  # pragma: no cover - defensive for CI only.
-            print("ERROR: Failed to install requirements-ci.txt via pip.")
-            return exc.returncode or 1
-        except FileNotFoundError as exc:  # pragma: no cover - defensive for CI only.
-            print(f"ERROR: {exc}")
-            return 1
+    validators = {spec: load_schema(spec.schema_path) for spec in CONFIG_SPECS}
 
-        loaded, missing = import_required_modules()
+    total_errors = 0
+    files_with_errors: Dict[str, int] = {}
 
-    if missing:
-        print("ERROR: Required Python modules are missing after reinstall attempt:")
-        for name, err in missing.items():
-            print(f"  - {name}: {err}")
+    for spec in CONFIG_SPECS:
+        violations = validate_spec(
+            spec,
+            validators[spec],
+            required=spec.relative_path in required,
+        )
+        if not violations:
+            continue
+        total_errors += len(violations)
+        files_with_errors[spec.relative_path] = len(violations)
+
+    if total_errors:
+        file_count = len(files_with_errors)
+        print(f"PREFLIGHT: FAIL ({total_errors} errors in {file_count} files)")
         return 1
 
-    print(f"Interpreter: {sys.executable}")
-    print(f"Python: {sys.version}")
-    print(
-        "Resolved versions:",
-        " ".join(
-            f"{name}={getattr(module, '__version__', 'unknown')}"
-            for name, module in loaded.items()
-        ),
-    )
+    print("PREFLIGHT: OK")
     return 0
 
 


### PR DESCRIPTION
## Summary
- add JSON Schemas for thresholds, threat model specs, evaluator rules, and gates policies
- replace `tools/ci_preflight.py` with YAML→JSON Schema validation, mode-aware required files, and clearer error reporting
- wire the validator into the demo/REAL workflows, add a `make validate` helper, and document how to run it locally

## Testing
- python tools/ci_preflight.py
- make validate


------
https://chatgpt.com/codex/tasks/task_e_68d3bac2c72c8329aa158fe7bedb037e