### PR TITLE
chore(pr-202): prune to minimal delta; drop generated artifacts; align paths; keep main as truth

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ results/*
 !results/.gitkeep
 !results/summary.csv
 !results/summary.svg
+!results/summary_index.json
 artifacts/
 .cache/
 dist/

--- a/Makefile
+++ b/Makefile
@@ -185,6 +185,7 @@ report: aggregate plot notes latest ## Publish artifacts to results/ and refresh
 	cp -f "$(RUN_DIR)/notes.md" $(RESULTS_DIR)/notes.md 2>/dev/null || true
 	cp -f "$(RUN_DIR)/run.json" $(RESULTS_DIR)/run.json 2>/dev/null || true
 	cp -f "$(RUN_DIR)/run_report.json" $(RESULTS_DIR)/run_report.json 2>/dev/null || true
+	cp -f "$(RUN_DIR)/summary_index.json" $(RESULTS_DIR)/summary_index.json 2>/dev/null || true
 	# Generate per-run HTML report + mirror to LATEST
 	python -m tools.report.html_report "$(RUN_DIR)"
 	if [ -e "$(RESULTS_DIR)/LATEST" ] || [ -L "$(RESULTS_DIR)/LATEST" ] || [ -f "$(RESULTS_DIR)/LATEST.path" ]; then \


### PR DESCRIPTION
## Summary
- keep summary_index.json tracked by adding an exception in .gitignore alongside existing summary artifacts
- mirror summary_index.json into the top-level results directory during the report publish step to match other run metadata

## Testing
- python3 -m pytest -q tests/test_summary_csv.py *(fails: requires populated results run directory in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d4732d35508329aa309a6feb7de3af