### PR TITLE
chore: prune PR-202 to minimal delta

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -185,7 +185,7 @@ report: aggregate plot notes latest ## Publish artifacts to results/ and refresh
 	cp -f "$(RUN_DIR)/notes.md" $(RESULTS_DIR)/notes.md 2>/dev/null || true
 	cp -f "$(RUN_DIR)/run.json" $(RESULTS_DIR)/run.json 2>/dev/null || true
 	cp -f "$(RUN_DIR)/run_report.json" $(RESULTS_DIR)/run_report.json 2>/dev/null || true
-	cp -f "$(RUN_DIR)/summary_index.json" $(RESULTS_DIR)/summary_index.json 2>/dev/null || true
+	cp -f "$(RUN_DIR)/summary_index.json" "$(RESULTS_DIR)/summary_index.json" 2>/dev/null || true
 	# Generate per-run HTML report + mirror to LATEST
 	python -m tools.report.html_report "$(RUN_DIR)"
 	if [ -e "$(RESULTS_DIR)/LATEST" ] || [ -L "$(RESULTS_DIR)/LATEST" ] || [ -f "$(RESULTS_DIR)/LATEST.path" ]; then \
@@ -320,6 +320,7 @@ mvp: ## Translator → REAL slice → aggregate + refresh LATEST (dry-run by def
 	if [ -e "$(LATEST_LINK)" ] || [ -L "$(LATEST_LINK)" ]; then
 		$(PYTHON) -m tools.report.html_report "$(LATEST_LINK)"
 	fi
+	cp -f "$$RUN_ROOT/summary_index.json" "$(RESULTS_DIR)/summary_index.json" 2>/dev/null || true
 	ROWS_WRITTEN="$$(RUN_ID="$$RUN_ID_VALUE" $(PYTHON) - <<-'PY'
 	import os
 	from pathlib import Path

--- a/tools/aggregate.py
+++ b/tools/aggregate.py
@@ -2,14 +2,20 @@
 
 # --- summary-index helpers (stable schema) ---
 from __future__ import annotations
-import json, os
+
+import json
+import os
 from typing import Dict, List, Tuple
 
 
 def build_summary_index_payload(
-    totals:int, callable_cnt:int, pass_cnt:int, fail_cnt:int,
-    top_pre:List[Tuple[str,int]], top_post:List[Tuple[str,int]],
-    malformed_cnt:int = 0
+    totals: int,
+    callable_cnt: int,
+    pass_cnt: int,
+    fail_cnt: int,
+    top_pre: List[Tuple[str, int]],
+    top_post: List[Tuple[str, int]],
+    malformed_cnt: int = 0,
 ) -> Dict:
     return {
         "totals": {"rows": totals, "callable": callable_cnt, "passes": pass_cnt, "fails": fail_cnt},
@@ -17,9 +23,7 @@ def build_summary_index_payload(
         "top_reasons": {"pre": top_pre, "post": top_post},
         "malformed": malformed_cnt,
     }
-
-
-def write_summary_index(run_dir:str, payload:Dict) -> str:
+def write_summary_index(run_dir: str, payload: Dict) -> str:
     p = os.path.join(run_dir, "summary_index.json")
     with open(p, "w", encoding="utf-8") as f:
         json.dump(payload, f, ensure_ascii=False, separators=(",", ":"))


### PR DESCRIPTION
## Summary
- mirror `summary_index.json` into the top-level results directory in both the report publishing path and the `make mvp` helper
- align `tools.aggregate` helpers with main by exposing the shared summary-index payload builder and writer

## Testing
- make mvp
- pytest -q tests/test_summary_csv.py

------
https://chatgpt.com/codex/tasks/task_e_68d50a74f4408329a96819a6ad2b4302