### PR TITLE
ci(demo-e2e): provide translator command to Makefile

### DIFF
--- a/.github/workflows/demo-e2e.yml
+++ b/.github/workflows/demo-e2e.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Run MVP (translate → run → aggregate)
         run: |
           echo "DRY_RUN=${DRY_RUN} STREAM=${STREAM}"
-          make mvp
+          make mvp MVP_TRANSLATE_CMD='python tools/translate.py --spec specs/threat_model.yaml --out results/$${RUN_ID}/cases.jsonl'
 
       - name: Locate latest run dir
         id: findrun


### PR DESCRIPTION
## Summary
- ensure the Demo E2E workflow passes the translate command when invoking `make mvp`

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d52a5c65148329a19c2022cd28cc89