### PR TITLE
Ensure mk_report import works without PYTHONPATH

### DIFF
--- a/tools/mk_report.py
+++ b/tools/mk_report.py
@@ -1,6 +1,12 @@
 from pathlib import Path
 import sys, json, csv
 
+# --- begin bootstrap so `from tools...` works without PYTHONPATH ---
+here = Path(__file__).resolve()
+repo_root = here.parent.parent  # <repo>/tools/.. => <repo>
+if str(repo_root) not in sys.path:
+    sys.path.insert(0, str(repo_root))
+# --- end bootstrap ---
 
 def resolve_run_dir(path: Path) -> Path:
     """Resolve symlinks and fallback pointer files like results/LATEST.path."""


### PR DESCRIPTION
## Summary
- add a sys.path bootstrap to tools/mk_report.py so it can import tools.report without PYTHONPATH

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d67177d01883298f1319840a3cb7d9