### PR TITLE
ci(guided): fix heredoc in full report step (robust fallback)

### DIFF
--- a/.github/workflows/demo-guided.yml
+++ b/.github/workflows/demo-guided.yml
@@ -167,7 +167,8 @@ jobs:
           # If still missing, write a minimal degraded page via a safe, aligned heredoc
           if [ ! -s "$RUN_DIR/index.html" ]; then
             python - "$RUN_DIR" <<'PY'
-from pathlib import Path, sys
+from pathlib import Path
+import sys
 rd = Path(sys.argv[1])
 html = rd / "index.html"
 html.write_text(


### PR DESCRIPTION
## Summary
- replace the guided demo full report step with an aligned heredoc fallback so the action no longer aborts on EOF errors

## Testing
- not run (workflow change)


------
https://chatgpt.com/codex/tasks/task_e_68d685d441fc8329930d7a478883d579