### PR TITLE
Address feedback: fix RUN_DIR usage in demo summary step

### DIFF
--- a/.github/workflows/demo-guided.yml
+++ b/.github/workflows/demo-guided.yml
@@ -192,7 +192,6 @@ jobs:
 
       - name: Append mini-report to summary
         env:
-          RD: ${{ env.RUN_DIR }}
           SUM: ${{ github.step_summary }}
           GROQ_MODEL: ${{ env.GROQ_MODEL }}
           TRIALS: ${{ env.TRIALS }}
@@ -200,7 +199,10 @@ jobs:
         run: |
           python - <<'PY'
           import csv, os, pathlib
-          rd = pathlib.Path(os.environ["RD"])
+          try:
+              rd = pathlib.Path(os.environ["RUN_DIR"])
+          except KeyError as exc:
+              raise SystemExit("RUN_DIR is not defined in the environment") from exc
           sum_md = pathlib.Path(os.environ["SUM"])
           model = os.environ.get("GROQ_MODEL","")
           trials = os.environ.get("TRIALS","")


### PR DESCRIPTION
## Summary
- read RUN_DIR directly from the environment when appending the guided demo summary
- fail fast with a clear error if RUN_DIR is missing so the workflow surfaces the issue earlier

## Testing
- not run (GitHub Actions workflow)


------
https://chatgpt.com/codex/tasks/task_e_68d69e261e6c83299611f902349c47d0