### PR TITLE
Report: add literal Trial I/O table (prompts + responses) and context badges

### DIFF
--- a/tools/report/html_utils.py
+++ b/tools/report/html_utils.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+import html
+
+
+def esc(s: object) -> str:
+    if s is None:
+        return ""
+    return html.escape(str(s), quote=True)
+
+
+def preview_block(full_text: str, max_len: int = 160) -> str:
+    text = full_text or ""
+    short = (text[:max_len] + "…") if len(text) > max_len else text
+    return (
+        f"<details><summary><code>{esc(short)}</code></summary>"
+        f"<pre style='white-space:pre-wrap'>{esc(text)}</pre></details>"
+    )


### PR DESCRIPTION
## Summary
- replace the report builder to render a streamlined HTML page with model/seed badges and artifact links
- stream rows.jsonl defensively to build a Trial I/O table that truncates previews and reveals full prompt/response text on demand
- add reusable HTML helpers for escaping and preview blocks to keep rendering safe

## Testing
- python -m compileall tools/mk_report.py tools/report/html_utils.py

------
https://chatgpt.com/codex/tasks/task_e_68d6a8d4dec88329a5c8062cba94271e